### PR TITLE
Creating a JSON Export Button for Form

### DIFF
--- a/src/views/FormBuilder.svelte
+++ b/src/views/FormBuilder.svelte
@@ -7,7 +7,7 @@
         validateFields,
     } from "src/core/formDefinition";
     import { FolderSuggest } from "src/suggesters/suggestFolder";
-    import { setIcon, Setting, App, Notice } from "obsidian";
+    import { setIcon, Setting, App } from "obsidian";
     import FormRow from "./components/FormRow.svelte";
     import InputBuilderDataview from "./components/inputBuilderDataview.svelte";
     import InputBuilderSelect from "./components/InputBuilderSelect.svelte";
@@ -90,11 +90,6 @@
         if (!isValidFormDefinition(definition)) return;
         onPreview(definition);
     };
-    const handleExport = () => {
-        if (!isValidFormDefinition(definition)) return;
-        navigator.clipboard.writeText(JSON.stringify(definition));
-        new Notice("Form has been copied to the clipboard");
-    };
 </script>
 
 <div class="flex column gap2 wrapper modal-form">
@@ -149,11 +144,6 @@
                 <button type="button" class="mod-warning" on:click={onCancel}
                     >Cancel</button
                 >
-                <button
-                    type="button"
-                    use:setIcon={"clipboard-copy"}
-                    on:click={handleExport}
-                    disabled={!isValid}/>
             </div>
             {#if errors.length > 0}
                 <h3 style="margin: 0;">

--- a/src/views/FormBuilder.svelte
+++ b/src/views/FormBuilder.svelte
@@ -7,7 +7,7 @@
         validateFields,
     } from "src/core/formDefinition";
     import { FolderSuggest } from "src/suggesters/suggestFolder";
-    import { setIcon, Setting, App } from "obsidian";
+    import { setIcon, Setting, App, Notice } from "obsidian";
     import FormRow from "./components/FormRow.svelte";
     import InputBuilderDataview from "./components/inputBuilderDataview.svelte";
     import InputBuilderSelect from "./components/InputBuilderSelect.svelte";
@@ -90,6 +90,11 @@
         if (!isValidFormDefinition(definition)) return;
         onPreview(definition);
     };
+    const handleExport = () => {
+        if (!isValidFormDefinition(definition)) return;
+        navigator.clipboard.writeText(JSON.stringify(definition));
+        new Notice("Form has been copied to the clipboard");
+    };
 </script>
 
 <div class="flex column gap2 wrapper modal-form">
@@ -144,6 +149,11 @@
                 <button type="button" class="mod-warning" on:click={onCancel}
                     >Cancel</button
                 >
+                <button
+                    type="button"
+                    use:setIcon={"clipboard-copy"}
+                    on:click={handleExport}
+                    disabled={!isValid}/>
             </div>
             {#if errors.length > 0}
                 <h3 style="margin: 0;">

--- a/src/views/ManageFormsView.ts
+++ b/src/views/ManageFormsView.ts
@@ -1,5 +1,5 @@
 import ModalFormPlugin from "../main";
-import { ItemView, Setting, WorkspaceLeaf } from "obsidian";
+import { ItemView, Notice, Setting, WorkspaceLeaf } from "obsidian";
 
 export const MANAGE_FORMS_VIEW = "modal-form-manage-forms-view";
 
@@ -77,6 +77,13 @@ export class ManageFormsView extends ItemView {
                     btn.setButtonText('Duplicate').onClick(() => {
                         this.plugin.duplicateForm(form);
                     })
+                })
+                .addButton(button => {
+                    button.setIcon('clipboard-copy')
+                    button.onClick(() => {
+                        navigator.clipboard.writeText(JSON.stringify(form, null, 2));
+                        new Notice("Form has been copied to the clipboard");
+                    });
                 })
                 ;
         })


### PR DESCRIPTION
I implemented the code for the export function, and it was straightforward as it required only a small change. 

Unfortunately, I initially implemented the button in the form creation view. I was about to create a pull request when I realized it would be better placed in the FormsManageView. So, there's one extra commit, but I didn't want to delete it to occasionally avoid disrupting the commit history.

By the way, I also had the idea to add an import feature now. What do you think?"