### PR TITLE
default values example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ const values = {
   description: 'This is a default description.',
 };
 
-api.openModalForm('example-form', { values });
+const modalForm = app.plugins.plugins.modalforms.api;
+const result = await modalForm.openForm('example-form', { values: values });
 ```
 In this example, the form will open with the `title` field pre-filled with `My Default Title` and the `description` field pre-filled with `This is a default description.`.
 


### PR DESCRIPTION
A small fix to default values definition example.
1. A bit clearer API method usage.
2. Missing `values` key before `values` object.

Basically I used usage example given [here](https://github.com/danielo515/obsidian-modal-form/issues/48#issuecomment-1739270056). Thanks for your work!