### PR TITLE
Updated limitedForm to allow FormOptions to be used

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -102,28 +102,36 @@ export class API {
         }
     }
 
-    public limitedForm(name: string, opts: limitOptions): Promise<FormResult> {
+    /**
+     * Opens a named form, limiting/filtering the fields included
+     * @param {string} name - The name of the form to open
+     * @param {limitOptions} limitOpts - The options to apply when filtering fields 
+     * @param {FormOptions} formOpts - Form options to use when opening the form once filtered
+     * @returns {Promise<FormResult>} - A promise that resolves with the form result
+     * @throws {ModalFormError} - Throws an error if the form definition is not found
+     */
+    public limitedForm(name: string, limitOpts: limitOptions, formOpts?: FormOptions): Promise<FormResult> {
         const formDefinition = this.getFormByName(name);
         let newFormDefinition: FormDefinition;
         if (formDefinition) {
-            if (isOmitOption(opts)) {
-                const omit = opts.omit;
+            if (isOmitOption(limitOpts)) {
+                const omit = limitOpts.omit;
                 newFormDefinition = {
                     ...formDefinition,
                     fields: formDefinition.fields.filter((field) => !omit.includes(field.name)),
                 };
-            } else if (isPickOption(opts)) {
+            } else if (isPickOption(limitOpts)) {
                 newFormDefinition = {
                     ...formDefinition,
                     fields: formDefinition.fields.filter((field) => opts.pick.includes(field.name)),
                 };
             } else {
                 throw new ModalFormError(
-                    "Invalid options provided to limitedForm",
-                    `GOT: ${JSON.stringify(opts)}`,
+                    "Invalid limit options provided to limitedForm",
+                    `GOT: ${JSON.stringify(limitOpts)}`,
                 );
             }
-            return this.openModalForm(newFormDefinition);
+            return this.openModalForm(newFormDefinition, formOpts);
         } else {
             const error = new ModalFormError(`Form definition ${name} not found`);
             log_error(error);

--- a/src/API.ts
+++ b/src/API.ts
@@ -123,7 +123,7 @@ export class API {
             } else if (isPickOption(limitOpts)) {
                 newFormDefinition = {
                     ...formDefinition,
-                    fields: formDefinition.fields.filter((field) => opts.pick.includes(field.name)),
+                    fields: formDefinition.fields.filter((field) => limitOpts.pick.includes(field.name)),
                 };
             } else {
                 throw new ModalFormError(


### PR DESCRIPTION
- Added a jsdoc for limitedForm
- Renamed `opts` to `limitOpts` for clarity 
- Added optional argument `formOpts` which is supplied to `openModalForm` when called
    - Allows for form options like default values to be supplied when using a limitedForm