### PR TITLE
Allow decimal inputs for number fields

### DIFF
--- a/src/FormModal.ts
+++ b/src/FormModal.ts
@@ -107,6 +107,7 @@ export class FormModal extends Modal {
                 case "number":
                     return fieldBase.addText((text) => {
                         text.inputEl.type = "number";
+                        text.inputEl.step = "any";
                         subToErrors(text.inputEl);
                         text.onChange((val) => {
                             if (val !== "") {


### PR DESCRIPTION
Bugfix for https://github.com/danielo515/obsidian-modal-form/issues/186

Sets the HTML input property `step` to `any` when field type is `number` - allowing non-whole numbers to be input.

This aligns the frontend visual feedback to the user with the backend validation, which would previously let inputs through, but apply CSS rules for invalid input.

---

Would be nice to have this configurable in the modal form editor as a future enhancement, along with `min` and `max` attributes.