### PR TITLE
Add helpUrl to  manifest.json for HelpMate integration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
 	"author": "Danielo Rodriguez",
 	"authorUrl": "https://danielo.es",
 	"fundingUrl": "https://www.buymeacoffee.com/danielo515",
+    "helpUrl": "https://danielorodriguez.com/obsidian-modal-form/",
 	"isDesktopOnly": false,
 	"version": "1.40.4"
 }


### PR DESCRIPTION
This adds your documentation as a registered element in the manifest and tools like HelpMate can incorporate this so your documentation can be available directly in obsidian in a side pane.