### PR TITLE
Feature: async dataview query support

### DIFF
--- a/src/std/index.ts
+++ b/src/std/index.ts
@@ -191,7 +191,7 @@ ${body}`;
 }
 
 /**
- * Creates an function from a string that is supposed to be a function body.
+ * Creates an async function from a string that is supposed to be a function body.
  * It ensures the "use strict" directive is present and returns the function.
  * Because the parsing can fail, it returns an Either.
  * The reason why the type arguments are reversed is because

--- a/src/std/index.ts
+++ b/src/std/index.ts
@@ -189,3 +189,24 @@ ${body}`;
         return left(ensureError(e));
     }
 }
+
+/**
+ * Creates an function from a string that is supposed to be a function body.
+ * It ensures the "use strict" directive is present and returns the function.
+ * Because the parsing can fail, it returns an Either.
+ * The reason why the type arguments are reversed is because
+ * we often know what the function input types should be, but
+ * we can't trust the function body to return the correct type, so by default1t it will be unknown
+ * The returned function is also wrapped to never throw and return an Either instead
+ */
+export function parseAsyncFunctionBody<Args extends unknown[], T>(body: string, ...args: string[]) {
+    const fnBody = `"use strict";
+${body}`;
+    try {
+        const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+        const fn = new AsyncFunction(...args, fnBody) as (...args: Args) => Promise<T>;
+        return right(fn);
+    } catch (e) {
+        return left(ensureError(e));
+    }
+}

--- a/src/suggesters/suggestFromDataview.ts
+++ b/src/suggesters/suggestFromDataview.ts
@@ -8,7 +8,7 @@ import { createRegexFromInput } from "./createRegexFromInput";
  * For now, we are not very strict with the checks and just throw errors
  */
 export class DataviewSuggest extends AbstractInputSuggest<string> {
-    sandboxedQuery: SafeDataviewQuery
+    sandboxedQuery: SafeDataviewQuery;
 
     constructor(
         public inputEl: HTMLInputElement,
@@ -16,14 +16,16 @@ export class DataviewSuggest extends AbstractInputSuggest<string> {
         public app: App,
     ) {
         super(app, inputEl);
-        this.sandboxedQuery = sandboxedDvQuery(dvQuery)
+        this.sandboxedQuery = sandboxedDvQuery(dvQuery);
     }
 
-    getSuggestions(inputStr: string): string[] {
-        const result = executeSandboxedDvQuery(this.sandboxedQuery, this.app)
-        if (!inputStr) { return result }
-        const regex = createRegexFromInput(inputStr)
-        return result.filter((r) => regex.test(r))
+    async getSuggestions(inputStr: string): Promise<string[]> {
+        const result = await executeSandboxedDvQuery(this.sandboxedQuery, this.app);
+        if (!inputStr) {
+            return result;
+        }
+        const regex = createRegexFromInput(inputStr);
+        return result.filter((r) => regex.test(r));
     }
 
     renderSuggestion(option: string, el: HTMLElement): void {

--- a/src/views/components/MultiSelectModel.ts
+++ b/src/views/components/MultiSelectModel.ts
@@ -38,10 +38,10 @@ export function MultiSelectModel(
             );
         }
     }
-    updateRemainingOptions();
     switch (source) {
         case "dataview":
         case "fixed": {
+            updateRemainingOptions();
             return {
                 createInput(element: HTMLInputElement) {
                     const unsubscribe = remainingOptions.subscribe((options) => {

--- a/src/views/components/inputBuilderDataview.svelte
+++ b/src/views/components/inputBuilderDataview.svelte
@@ -4,20 +4,24 @@
     import { pipe } from "@std";
     import { App } from "obsidian";
     import Code from "./Code.svelte";
+    import { onMount } from "svelte";
 
     export let index: number;
     export let value: string = "";
     export let app: App;
     let error = "";
-    const logger = (err: { message: string }) => (error = err.message);
-    const makePreview = function (query: string) {
-        error = "";
-        return pipe(query, sandboxedDvQuery, (query) =>
-            executeSandboxedDvQuery(query, app, logger),
-        );
-    };
+    let preview: string | string[] = "";
+    async function updatePreview() {
+        try {
+            const queryFn = sandboxedDvQuery(value);
+            preview = await executeSandboxedDvQuery(queryFn, app, (err) => (error = err.message));
+        } catch (err: any) {
+            error = err.message;
+        }
+    }
+    onMount(updatePreview);
     $: id = `dataview_${index}`;
-    $: preview = makePreview(value);
+    $: value, updatePreview();
 </script>
 
 <FormRow label="Dataview Query" {id}>


### PR DESCRIPTION
Adds support for async Dataview Queries.
Helpful for pulling multiselect & dataview options from other Obsidian plugins' APIs
This functionality has only been tested using the metadata menu plugin
original discussion linked here: https://forum.obsidian.md/t/new-plugin-modal-form-integrate-forms-into-quickadd-templater-etc/67103/73