### PR TITLE
fix: set initial value of fixed-source select fields, if provided

### DIFF
--- a/src/FormModal.ts
+++ b/src/FormModal.ts
@@ -226,6 +226,7 @@ export class FormModal extends Modal {
                                 fieldInput.options.forEach((option) => {
                                     element.addOption(option.value, option.label);
                                 });
+                                initialValue !== undefined && element.setValue(String(initialValue));
                                 fieldStore.value.set(element.getValue());
                                 element.onChange(fieldStore.value.set);
                             });


### PR DESCRIPTION
This simple fix allows an initial/default value to be set for `select` type fields with `fixed` source (i.e., drop-down option lists). I believe this classes as a fix, as the [readme](https://github.com/danielo515/obsidian-modal-form/blob/master/README.md#providing-default-values-when-opening-a-form) gives the impression that default values should be generally applicable.

I'm not aware of any downsides to this. If the initial value provided by the user does not match the field's options, the field's value in the constructed form will simply be blank (""). Previously, the first option would always be selected by default.