### PR TITLE
fix: allow decimal inputs for number fields

### DIFF
--- a/src/views/components/Form/InputField.svelte
+++ b/src/views/components/Form/InputField.svelte
@@ -7,7 +7,8 @@
 </script>
 
 {#if inputType === "number"}
-    <input type="number" bind:value={$value} />
+    <!-- Step is required to allow decimals, see #430 & #186 -->
+    <input type="number" step="any" bind:value={$value} />
 {:else if inputType === "text"}
     <input type="text" bind:value={$value} />
 {:else if inputType === "email"}


### PR DESCRIPTION
Fixes #430 (original issue #186).

I attempted to add a regression test within `formEngine.test.ts`, however the step is an actual HTML input prop, not part of the formEngine validation. Testing of HTML inputs in this way would require Svelte component testing or higher level e2e testing which doesn't seem to be set up, if I missed it please let me know.

For reference this test passes with current code (bugged):
```ts
  it("should accept decimal numbers for number fields", () => {
    const onSubmitMock = jest.fn();
    const formEngine = makeFormEngine({
      onSubmit: onSubmitMock,
      onCancel: console.log,
    });

    const numberField = formEngine.addField({ name: "decimalField" });
    numberField.value.set(1.5);

    formEngine.triggerSubmit();
    expect(onSubmitMock).toHaveBeenCalledWith({
      decimalField: 1.5,
    });
    expect(get(formEngine.isValid)).toBe(true);
    expect(get(numberField.errors)).toStrictEqual([]);
  });
  ```