### PR TITLE
Fix variable name case in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This method returns the form data formatted as a string matching the provided te
 <%*
 const modalForm = app.plugins.plugins.modalforms.api;
 const result = await modalForm.openForm('example-form');
-tR += result.asString('{{Name}} is {{age}} years old and his/her favorite food is {{favorite_meal}}. Family status: {{is_family}}');
+tR += result.asString('{{name}} is {{age}} years old and his/her favorite food is {{favorite_meal}}. Family status: {{is_family}}');
 -%>
 ```
 


### PR DESCRIPTION
"Name" corresponds to label, "name" corresponds to actual variable in form.  "Name" results in 
{{Name}} is <age> years old ... in template. 
"name" will result in the actual <name> text input into the form to be fit in.