### PR TITLE
fix: wrap frontmatter command output in --- delimiters

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -121,7 +121,7 @@ Here are some examples of how to use the new template syntax:
 
 #### Frontmatter Command
 
-The frontmatter command controls which form fields appear in the YAML frontmatter section of your note:
+The frontmatter command controls which form fields appear in the YAML frontmatter section of your note. It automatically wraps the output in `---` delimiters, producing valid YAML frontmatter:
 
 ```plaintext
 {# frontmatter pick: title, tags #}
@@ -143,6 +143,8 @@ If no options are specified, all form fields will be included in the frontmatter
 ```plaintext
 {# frontmatter #}
 ```
+
+> **Note:** You do not need to manually add `---` around the frontmatter command — the delimiters are included automatically in the output.
 
 ## Templater Support
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -121,10 +121,12 @@ Here are some examples of how to use the new template syntax:
 
 #### Frontmatter Command
 
-The frontmatter command controls which form fields appear in the YAML frontmatter section of your note. It automatically wraps the output in `---` delimiters, producing valid YAML frontmatter:
+The frontmatter command controls which form fields appear in the YAML frontmatter section of your note. It outputs raw YAML, so you need to wrap it in `---` delimiters for valid frontmatter:
 
 ```plaintext
+---
 {# frontmatter pick: title, tags #}
+---
 ```
 
 Options:
@@ -135,16 +137,18 @@ Options:
 You can combine both options:
 
 ```plaintext
+---
 {# frontmatter pick: title, tags, date omit: draft #}
+---
 ```
 
 If no options are specified, all form fields will be included in the frontmatter:
 
 ```plaintext
+---
 {# frontmatter #}
+---
 ```
-
-> **Note:** You do not need to manually add `---` around the frontmatter command — the delimiters are included automatically in the output.
 
 ## Templater Support
 
@@ -201,7 +205,9 @@ When you execute these commands:
 Here's a complete template example that combines variables and frontmatter:
 
 ```plaintext
+---
 {# frontmatter pick: title, tags #}
+---
 
 # {{title}}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-modal-form",
-    "version": "1.62.0",
+    "version": "1.63.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-modal-form",
-            "version": "1.62.0",
+            "version": "1.63.0",
             "license": "MIT",
             "dependencies": {
                 "fp-ts": "^2.16.1",

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -246,7 +246,7 @@ describe("parseTemplate", () => {
             E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
             E.map(tap("executed")),
         );
-        expect(result).toEqual(E.of(stringifyYaml({ name: "John", age: 18 })));
+        expect(result).toEqual(E.of(`---\n${stringifyYaml({ name: "John", age: 18 })}---\n`));
     });
     it("Should properly execute a template with a frontmatter command that specifies a pick", () => {
         const template = "{# frontmatter pick: name #}";
@@ -256,6 +256,6 @@ describe("parseTemplate", () => {
             E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
             E.map(tap("executed")),
         );
-        expect(result).toEqual(E.of(stringifyYaml({ name: "John" })));
+        expect(result).toEqual(E.of(`---\n${stringifyYaml({ name: "John" })}---\n`));
     });
 });

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -246,7 +246,7 @@ describe("parseTemplate", () => {
             E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
             E.map(tap("executed")),
         );
-        expect(result).toEqual(E.of(`---\n${stringifyYaml({ name: "John", age: 18 })}---\n`));
+        expect(result).toEqual(E.of(stringifyYaml({ name: "John", age: 18 })));
     });
     it("Should properly execute a template with a frontmatter command that specifies a pick", () => {
         const template = "{# frontmatter pick: name #}";
@@ -256,6 +256,6 @@ describe("parseTemplate", () => {
             E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
             E.map(tap("executed")),
         );
-        expect(result).toEqual(E.of(`---\n${stringifyYaml({ name: "John" })}---\n`));
+        expect(result).toEqual(E.of(stringifyYaml({ name: "John" })));
     });
 });

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -231,6 +231,7 @@ function asFrontmatterString(data: Record<string, unknown>) {
             }),
             R.filterMapWithIndex((key, value) => (!omit.includes(key) ? O.some(value) : O.none)),
             stringifyYaml,
+            (yaml) => `---\n${yaml}---\n`,
         );
 }
 

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -231,7 +231,6 @@ function asFrontmatterString(data: Record<string, unknown>) {
             }),
             R.filterMapWithIndex((key, value) => (!omit.includes(key) ? O.some(value) : O.none)),
             stringifyYaml,
-            (yaml) => `---\n${yaml}---\n`,
         );
 }
 

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -221,6 +221,8 @@ export function parsedTemplateToString(parsedTemplate: ParsedTemplate): string {
     );
 }
 
+// Outputs raw YAML without `---` delimiters so it can be placed inside existing frontmatter.
+// Users are expected to wrap the command in `---` in their templates.
 function asFrontmatterString(data: Record<string, unknown>) {
     return ({ pick, omit }: { pick: string[]; omit: string[] }): string =>
         pipe(


### PR DESCRIPTION
The {# frontmatter #} template command now automatically wraps its YAML
output in --- delimiters, producing valid frontmatter that Obsidian can
recognize. Previously, the command output raw YAML without delimiters,
requiring users to manually add --- around the command in their templates.

Also updates the documentation to clarify this behavior.

Closes #439