### PR TITLE
Update GitHub Actions to latest versions and Node.js 22

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.x
 
@@ -26,7 +26,7 @@ jobs:
               run: ./build-docs.sh
 
             - name: Deploy to GitHub Pages
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@v4
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: ./site

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,10 +6,11 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Use Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
+                  node-version: 22
                   cache: "npm"
 
             - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "npm"
 
             - name: Install dependencies


### PR DESCRIPTION
## Summary
This pull request updates GitHub Actions workflows to use the latest stable versions of commonly used actions and upgrades the Node.js runtime version to 22 across all CI/CD pipelines.

## Key Changes
- **actions/checkout**: Updated from v3 to v4
- **actions/setup-python**: Updated from v2 to v5 in docs workflow
- **actions/setup-node**: Updated from v3 to v4 in pull-request workflow (already v4 in release workflow)
- **peaceiris/actions-gh-pages**: Updated from v3 to v4 in docs workflow
- **Node.js version**: Upgraded from 20 to 22 in release workflow and added explicit `node-version: 22` configuration to pull-request workflow

## Implementation Details
- All action updates maintain backward compatibility with existing workflow configurations
- The Node.js version upgrade to 22 is applied consistently across both the release and pull-request workflows
- No changes to workflow logic or job structure; this is purely a dependency update

https://claude.ai/code/session_01CqGve5RpWX5dcyT414QEMY