### PR TITLE
docs: add guide for self-contained forms in Templater templates

### DIFF
--- a/docs/FormBuilder.md
+++ b/docs/FormBuilder.md
@@ -277,3 +277,6 @@ const form = modalForm.builder("example-contact-form", "Example Contact Form")
 
 modalForm.openForm(form);
 ```
+
+!!! tip
+    You can use the builder to define forms entirely inside a Templater template, making them fully self-contained and easy to share. See [Self-contained forms in Templater templates](self-contained-forms.md) for complete examples.

--- a/docs/advanced-examples.md
+++ b/docs/advanced-examples.md
@@ -36,6 +36,9 @@ the form values will not reflect this change and you may be overwriting some cha
 The values the form understand and that are present in the frontmatter, will be populated with the values on the frontmatter.
 Then, when you submit the form, the new values will overwrite the old ones, leaving the rest untouched.
 
+!!! tip
+    If you want the form definition to live inside the template itself instead of in the plugin settings, you can use the Builder API to create fully [self-contained forms in Templater templates](self-contained-forms.md).
+
 ## Making calling forms more convenient
 
 If you are using templater, you can make calling forms more convenient by using the following snippet:

--- a/docs/self-contained-forms.md
+++ b/docs/self-contained-forms.md
@@ -49,6 +49,12 @@ const result = await modalForm.openForm(
   { values: { date: tp.date.now("YYYY-MM-DD") } }
 );
 -%>
+# Meeting – <% result.getValue("date").value %>
+
+Attendees:: <% result.getValue("attendees").value %>
+
+## Agenda
+<% result.getValue("agenda").value %>
 ```
 
 ## Tips

--- a/docs/self-contained-forms.md
+++ b/docs/self-contained-forms.md
@@ -1,0 +1,58 @@
+# Self-contained forms in Templater templates
+
+A common pattern when using Modal Form with [Templater](https://github.com/SilentVoid13/Templater) is to define forms in the plugin settings and then reference them by name from your templates. However, this means the form definition lives separately from the template that uses it.
+
+Using the **Builder API**, you can define and open a form entirely within a Templater template, making it fully self-contained. This is useful when:
+
+- You want the form definition to live next to the logic that uses it.
+- You are sharing a template with others and don't want them to manually create a form in settings.
+- You need a quick, one-off form that doesn't need to be reusable.
+
+## Example: a simple book note template
+
+```javascript
+<%*
+const modalForm = app.plugins.plugins.modalforms.api;
+
+const result = await modalForm.openForm(
+  modalForm.builder("book-note", "New Book Note")
+    .text({ name: "title", label: "Book Title", required: true })
+    .text({ name: "author", label: "Author", required: true })
+    .select({ name: "status", label: "Status", options: ["To Read", "Reading", "Finished"] })
+    .slider({ name: "rating", label: "Rating", min: 1, max: 5 })
+    .build()
+);
+-%>
+# <% result.getValue("title").value %>
+
+Author:: <% result.getValue("author").value %>
+Status:: <% result.getValue("status").value %>
+Rating:: <% result.getValue("rating").value %>/5
+```
+
+The key idea is simple: instead of passing a form name string to `openForm`, you pass the result of `builder(...).build()` directly.
+
+## Passing initial values
+
+You can still pass options like `values` to pre-fill fields, just as you would with a named form:
+
+```javascript
+<%*
+const modalForm = app.plugins.plugins.modalforms.api;
+
+const result = await modalForm.openForm(
+  modalForm.builder("meeting-note", "New Meeting")
+    .date({ name: "date", label: "Date" })
+    .text({ name: "attendees", label: "Attendees" })
+    .textarea({ name: "agenda", label: "Agenda" })
+    .build(),
+  { values: { date: tp.date.now("YYYY-MM-DD") } }
+);
+-%>
+```
+
+## Tips
+
+- The form `name` in `builder("name")` is only used internally and doesn't need to match any form in settings.
+- The builder returns a new instance on each method call, so you can chain freely.
+- Since the form is defined inline, you can use JavaScript variables to dynamically configure it (e.g., populate select options from Dataview queries).

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -165,6 +165,9 @@ The form will first replace `{{NAME}}` with the value from your form, and then T
 
 Note: This feature is only available if you have the Templater plugin installed and enabled in your vault.
 
+!!! tip
+    You can also use the [Builder API](FormBuilder.md) to define forms directly inside your Templater templates, making them fully self-contained. See [Self-contained forms in Templater templates](self-contained-forms.md) for examples.
+
 ## Template Commands
 
 You can create dedicated Obsidian commands for your templates, making them easily accessible through the command palette. This is useful for frequently used templates that you want to access quickly without navigating through menus.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - Importing a form: import-forms.md
     - Templates: templates.md
     - Form builder API: FormBuilder.md
+    - Self-contained forms: self-contained-forms.md
     - Blog:
           - blog/index.md
 plugins:


### PR DESCRIPTION
Adds a new documentation page showing how to use the Builder API to define
forms inline within Templater templates, making them fully self-contained.

https://claude.ai/code/session_01KFX4RHQQWJ69tc8Q1jta7P