### PR TITLE
feat: expose field name on rendered form fields for CSS targeting

### DIFF
--- a/docs/advanced-examples.md
+++ b/docs/advanced-examples.md
@@ -84,3 +84,26 @@ Which will look like this in the form:
 You can take advantage of the preview to experiment a bit with what you will get in the input
 
 ![preview](Screenshot 2024-05-08 at 15.07.15.png)
+
+## Styling specific fields with CSS
+
+Every rendered field exposes its form-field name so you can target it from a CSS snippet.
+The wrapper element around each field gets a `data-field-name` attribute, and basic
+inputs (`text`, `number`, `textarea`, `select`, ...) also get a matching `name` attribute.
+
+Given a field called `rating`, both of these selectors will work in an Obsidian CSS snippet:
+
+```css
+/* Target the whole row (label + input) */
+.modal-form .setting-item[data-field-name="rating"] {
+    background: var(--background-secondary);
+}
+
+/* Target only the input element */
+.modal-form input[name="rating"] {
+    font-weight: bold;
+}
+```
+
+This is useful, for example, to render a slider as a star-rating component, or to
+highlight a specific field without affecting the rest of the form.

--- a/src/views/components/Form/InputDataview.svelte
+++ b/src/views/components/Form/InputDataview.svelte
@@ -36,6 +36,11 @@
     }
 </script>
 
-<ObsidianInputWrapper {errors} label={field.label || field.name} description={field.description}>
-    <input type="text" bind:value={$value} use:dataviewSuggest />
+<ObsidianInputWrapper
+    {errors}
+    name={field.name}
+    label={field.label || field.name}
+    description={field.description}
+>
+    <input type="text" name={field.name} bind:value={$value} use:dataviewSuggest />
 </ObsidianInputWrapper>

--- a/src/views/components/Form/InputField.svelte
+++ b/src/views/components/Form/InputField.svelte
@@ -4,21 +4,22 @@
     import { Writable } from "svelte/store";
     export let value: Writable<FieldValue>;
     export let inputType: "number" | "text" | "date" | "time" | "datetime" | "email" | "tel";
+    export let name = "";
 </script>
 
 {#if inputType === "number"}
     <!-- Step is required to allow decimals, see #430 & #186 -->
-    <input type="number" step="any" bind:value={$value} />
+    <input type="number" step="any" {name} bind:value={$value} />
 {:else if inputType === "text"}
-    <input type="text" bind:value={$value} />
+    <input type="text" {name} bind:value={$value} />
 {:else if inputType === "email"}
-    <input type="email" bind:value={$value} />
+    <input type="email" {name} bind:value={$value} />
 {:else if inputType === "tel"}
-    <input type="tel" bind:value={$value} />
+    <input type="tel" {name} bind:value={$value} />
 {:else if inputType === "date"}
-    <input type="date" bind:value={$value} />
+    <input type="date" {name} bind:value={$value} />
 {:else if inputType === "time"}
-    <input type="time" bind:value={$value} />
+    <input type="time" {name} bind:value={$value} />
 {:else if inputType === "datetime"}
-    <input type="datetime-local" bind:value={$value} />
+    <input type="datetime-local" {name} bind:value={$value} />
 {/if}

--- a/src/views/components/Form/InputFolder.svelte
+++ b/src/views/components/Form/InputFolder.svelte
@@ -31,6 +31,7 @@
 </script>
 
 <div
+    data-field-name={field.name}
     use:useSetting={{
         name: field.label || field.name,
         description: field.description || "",

--- a/src/views/components/Form/InputFolder.svelte
+++ b/src/views/components/Form/InputFolder.svelte
@@ -31,10 +31,10 @@
 </script>
 
 <div
-    data-field-name={field.name}
     use:useSetting={{
         name: field.label || field.name,
         description: field.description || "",
+        fieldName: field.name,
         customizer,
     }}
 >

--- a/src/views/components/Form/InputNote.svelte
+++ b/src/views/components/Form/InputNote.svelte
@@ -28,6 +28,11 @@
     }
 </script>
 
-<ObsidianInputWrapper {errors} label={field.label || field.name} description={field.description}>
-    <input type="text" bind:value={$value} use:noteSuggest />
+<ObsidianInputWrapper
+    {errors}
+    name={field.name}
+    label={field.label || field.name}
+    description={field.description}
+>
+    <input type="text" name={field.name} bind:value={$value} use:noteSuggest />
 </ObsidianInputWrapper>

--- a/src/views/components/Form/InputTextArea.svelte
+++ b/src/views/components/Form/InputTextArea.svelte
@@ -17,9 +17,10 @@
 
 <ObsidianInputWrapper
     {errors}
+    name={field.name}
     label={field.label || field.name}
     description={field.description}
     className="modal-form-textarea"
 >
-    <textarea bind:value={$value} use:customizeTextArea />
+    <textarea name={field.name} bind:value={$value} use:customizeTextArea />
 </ObsidianInputWrapper>

--- a/src/views/components/Form/ObsidianInputWrapper.svelte
+++ b/src/views/components/Form/ObsidianInputWrapper.svelte
@@ -5,10 +5,11 @@
     export let description = "";
     export let required = false;
     export let className = "";
+    export let name = "";
 </script>
 
 <!-- Trying to emulate native Obsidian settings -->
-<div class="setting-item {className}">
+<div class="setting-item {className}" data-field-name={name || undefined}>
     <div class="setting-item-info">
         <div class="setting-item-name">
             {label}

--- a/src/views/components/Form/ObsidianSelect.svelte
+++ b/src/views/components/Form/ObsidianSelect.svelte
@@ -32,16 +32,21 @@
     }
 </script>
 
-<ObsidianInput {errors} label={field.label || field.name} description={field.description}>
+<ObsidianInput
+    {errors}
+    name={field.name}
+    label={field.label || field.name}
+    description={field.description}
+>
     {#if input.source === "fixed"}
-        <select bind:value={$value} class="dropdown">
+        <select name={field.name} bind:value={$value} class="dropdown">
             {#each input.options as option}
                 <option value={option.value}>{option.label}</option>
             {/each}
         </select>
     {:else}
         {@const options = getNoteOptions(input.folder)}
-        <select bind:value={$value} class="dropdown">
+        <select name={field.name} bind:value={$value} class="dropdown">
             {#each Object.entries(options) as [value, label]}
                 <option {value}>{label}</option>
             {/each}

--- a/src/views/components/Form/ObsidianToggle.svelte
+++ b/src/views/components/Form/ObsidianToggle.svelte
@@ -21,6 +21,7 @@
 </script>
 
 <div
+    data-field-name={field.name}
     use:useSetting={{
         name: field.label || field.name,
         description: field.description || "",

--- a/src/views/components/Form/ObsidianToggle.svelte
+++ b/src/views/components/Form/ObsidianToggle.svelte
@@ -21,10 +21,10 @@
 </script>
 
 <div
-    data-field-name={field.name}
     use:useSetting={{
         name: field.label || field.name,
         description: field.description || "",
+        fieldName: field.name,
         customizer,
     }}
 >

--- a/src/views/components/Form/RenderField.svelte
+++ b/src/views/components/Form/RenderField.svelte
@@ -44,6 +44,7 @@
 
 {#if E.isLeft($isVisible)}
     <ObsidianInputWrapper
+        name={definition.name}
         label={definition.label || definition.name}
         description={definition.description}
         errors={visibleError}
@@ -80,6 +81,7 @@
     {:else if definition.input.type === "document_block"}
         <!-- I need to put this separated to be able to target the correct slot, it does not work inside #if -->
         <ObsidianInputWrapper
+            name={definition.name}
             label={definition.label || definition.name}
             description={definition.description}
         >
@@ -88,6 +90,7 @@
     {:else if definition.input.type === "image"}
         <ObsidianInputWrapper
             {errors}
+            name={definition.name}
             label={definition.label || definition.name}
             description={definition.description}
             required={definition.isRequired}
@@ -100,6 +103,7 @@
     {:else if definition.input.type === "file"}
         <ObsidianInputWrapper
             {errors}
+            name={definition.name}
             label={definition.label || definition.name}
             description={definition.description}
             required={definition.isRequired}
@@ -112,6 +116,7 @@
     {:else}
         <ObsidianInputWrapper
             {errors}
+            name={definition.name}
             label={definition.label || definition.name}
             description={definition.description}
             required={definition.isRequired}
@@ -123,7 +128,7 @@
             {:else if definition.input.type === "tag"}
                 <InputTag input={definition.input} {value} {errors} {app} />
             {:else}
-                <InputField {value} inputType={definition.input.type} />
+                <InputField name={definition.name} {value} inputType={definition.input.type} />
             {/if}
         </ObsidianInputWrapper>
     {/if}

--- a/src/views/components/Form/useObsidianSetting.ts
+++ b/src/views/components/Form/useObsidianSetting.ts
@@ -5,11 +5,15 @@ export function useSetting(
     field: {
         name: string;
         description: string;
+        fieldName?: string;
         customizer?: (setting: Setting) => void;
     },
 ) {
-    new Setting(element)
+    const setting = new Setting(element)
         .setName(field.name)
         .setDesc(field.description)
         .then(field.customizer || (() => {}));
+    if (field.fieldName) {
+        setting.settingEl.setAttribute("data-field-name", field.fieldName);
+    }
 }


### PR DESCRIPTION
## Summary

Adds the form-field `name` to every rendered field so users can target individual fields from a CSS snippet — the capability requested in #408.

- The wrapper `<div class="setting-item">` around each field now carries a `data-field-name="<name>"` attribute (via `ObsidianInputWrapper` for most fields; directly on the element for `toggle` and `folder` fields, which use Obsidian's native `Setting`).
- Basic inputs — `text`, `number`, `date`, `time`, `datetime`, `email`, `tel`, `textarea`, `select`, plus the note/dataview suggester inputs — also get a matching HTML `name` attribute.

With these, users can write CSS snippets like:

```css
.modal-form .setting-item[data-field-name="rating"] {
    background: var(--background-secondary);
}

.modal-form input[name="rating"] {
    font-weight: bold;
}
```

This unblocks use cases like styling a specific slider as a star-rating component or highlighting a single field without affecting the rest of the form.

Closes #408.

## Test plan

- [x] `npm run build` (lint + svelte-check + esbuild production bundle) passes
- [x] `npm run test` — all 159 tests pass, 2 pre-existing skipped
- [ ] Preview URL: open a form with any field and confirm inspecting the DOM shows the new `data-field-name` on the wrapper and `name` on the input
- [ ] Apply the CSS snippet from the docs to verify a specific field can be targeted

https://claude.ai/code/session_01UEaoV6X4vgUppNsAQD2Msg