### PR TITLE
fix: prevent duplicate selections in multiselect notes source

### DIFF
--- a/src/suggesters/suggestFile.ts
+++ b/src/suggesters/suggestFile.ts
@@ -21,6 +21,7 @@ export class FileSuggest extends AbstractInputSuggest<TFile> {
         public inputEl: HTMLInputElement,
         private strategy: FileStrategy,
         folder: string | string[],
+        private getExcludedBasenames: () => Iterable<string> = () => [],
     ) {
         super(app, inputEl);
         this.folders = Array.isArray(folder) ? folder : [folder];
@@ -34,8 +35,10 @@ export class FileSuggest extends AbstractInputSuggest<TFile> {
                 log_error(err);
             }
         });
+        const excluded = new Set(this.getExcludedBasenames());
         const enriched = pipe(
             files,
+            A.filter((file) => !excluded.has(file.basename)),
             A.map((file) => enrich_tfile(file, this.app)),
         );
 

--- a/src/views/components/MultiSelectModel.ts
+++ b/src/views/components/MultiSelectModel.ts
@@ -5,7 +5,7 @@ import { getMultiselectNoteFolders, inputTag, multiselect } from "src/core/input
 import { executeSandboxedDvQuery, sandboxedDvQuery } from "src/suggesters/SafeDataviewQuery";
 import { StringSuggest } from "src/suggesters/StringSuggest";
 import { FileSuggest } from "src/suggesters/suggestFile";
-import { Writable } from "svelte/store";
+import { Writable, get } from "svelte/store";
 
 export interface MultiSelectModel {
     createInput(element: HTMLInputElement): void;
@@ -64,11 +64,14 @@ export async function MultiSelectModel(
                                 return file.basename;
                             },
                             selectSuggestion(file) {
-                                values.update((x) => [...x, file.basename]);
+                                values.update((x) =>
+                                    x.includes(file.basename) ? x : [...x, file.basename],
+                                );
                                 return "";
                             },
                         },
                         folders,
+                        () => get(values) ?? [],
                     );
                 },
                 removeValue,


### PR DESCRIPTION
## Summary

Fixes the bug reported in #419: a multiselect field with the **Notes** source allowed the same note to be picked multiple times, and removing one of the duplicate badges removed all of them (because removal filters by value, not by index).

This brings the `notes` source in line with `fixed`/`dataview`, where selecting an option removes it from the suggestions list.

## Changes

- `FileSuggest` now accepts an optional `getExcludedBasenames: () => Iterable<string>` getter and filters those files out of the suggestion list every time `getSuggestions` runs.
- `MultiSelectModel` (notes branch) passes `() => get(values) ?? []` so already-selected notes never appear in the suggester. It also dedupes on add as a safety net.
- The other call site of `FileSuggest` (the single-note picker in `InputNote.svelte`) is unaffected — the new parameter defaults to an empty list.

## Test plan

- [x] `npm run build` (lint + svelte-check + esbuild production bundle) passes — only pre-existing warnings
- [x] `npm run test` — all 159 tests pass, 2 pre-existing skipped
- [ ] Preview URL: open a multiselect-from-notes form, pick a note, confirm it disappears from the suggestion list; remove the badge, confirm it reappears in the suggestions

Closes #419

https://claude.ai/code/session_016bJdn7LvRjaq5Vd1usL32V

---
_Generated by [Claude Code](https://claude.ai/code/session_016bJdn7LvRjaq5Vd1usL32V)_