### PR TITLE
feat: render field descriptions as markdown

### DIFF
--- a/src/views/components/Form/InputDataview.svelte
+++ b/src/views/components/Form/InputDataview.svelte
@@ -36,6 +36,6 @@
     }
 </script>
 
-<ObsidianInputWrapper {errors} label={field.label || field.name} description={field.description}>
+<ObsidianInputWrapper {errors} label={field.label || field.name} description={field.description} {app}>
     <input type="text" bind:value={$value} use:dataviewSuggest />
 </ObsidianInputWrapper>

--- a/src/views/components/Form/InputFolder.svelte
+++ b/src/views/components/Form/InputFolder.svelte
@@ -35,6 +35,7 @@
         name: field.label || field.name,
         description: field.description || "",
         customizer,
+        app,
     }}
 >
     <span style="display: none;">dummy to prevent the setting from being the first child</span>

--- a/src/views/components/Form/InputNote.svelte
+++ b/src/views/components/Form/InputNote.svelte
@@ -28,6 +28,6 @@
     }
 </script>
 
-<ObsidianInputWrapper {errors} label={field.label || field.name} description={field.description}>
+<ObsidianInputWrapper {errors} label={field.label || field.name} description={field.description} {app}>
     <input type="text" bind:value={$value} use:noteSuggest />
 </ObsidianInputWrapper>

--- a/src/views/components/Form/InputTextArea.svelte
+++ b/src/views/components/Form/InputTextArea.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Platform } from "obsidian";
+    import { App, Platform } from "obsidian";
     import { FieldDefinition } from "src/core/formDefinition";
     import { FieldValue } from "src/store/formEngine";
     import { Readable, Writable } from "svelte/store";
@@ -7,6 +7,7 @@
     export let field: FieldDefinition;
     export let value: Writable<FieldValue>;
     export let errors: Readable<string[]>;
+    export let app: App | undefined = undefined;
     function customizeTextArea(el: HTMLTextAreaElement) {
         if (Platform.isIosApp) el.style.width = "100%";
         else if (Platform.isDesktopApp) {
@@ -20,6 +21,7 @@
     label={field.label || field.name}
     description={field.description}
     className="modal-form-textarea"
+    {app}
 >
     <textarea bind:value={$value} use:customizeTextArea />
 </ObsidianInputWrapper>

--- a/src/views/components/Form/MarkdownDescription.svelte
+++ b/src/views/components/Form/MarkdownDescription.svelte
@@ -7,11 +7,20 @@
     const component = new Component();
     component.load();
     onDestroy(() => component.unload());
+    function showRenderError(el: HTMLElement, err: unknown) {
+        el.empty();
+        console.error("Failed to render markdown description", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        el.createDiv({
+            cls: "modal-form-description-error",
+            text: `Failed to render description: ${msg}`,
+        });
+    }
     function renderInto(el: HTMLElement, md: string) {
         el.empty();
         if (!md) return;
         MarkdownRenderer.render(app, md, el, "/", component).catch((e) =>
-            console.error("Failed to render markdown description", e),
+            showRenderError(el, e),
         );
     }
     function render(el: HTMLElement, currentText: string) {

--- a/src/views/components/Form/MarkdownDescription.svelte
+++ b/src/views/components/Form/MarkdownDescription.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import { App, Component, MarkdownRenderer } from "obsidian";
+    import { onDestroy } from "svelte";
+    export let app: App;
+    export let text: string;
+    export let className = "setting-item-description";
+    const component = new Component();
+    component.load();
+    onDestroy(() => component.unload());
+    function render(el: HTMLElement, currentText: string) {
+        el.empty();
+        if (currentText) MarkdownRenderer.render(app, currentText, el, "/", component);
+        return {
+            update(newText: string) {
+                el.empty();
+                if (newText) MarkdownRenderer.render(app, newText, el, "/", component);
+            },
+        };
+    }
+</script>
+
+<div class={className} use:render={text}></div>

--- a/src/views/components/Form/MarkdownDescription.svelte
+++ b/src/views/components/Form/MarkdownDescription.svelte
@@ -7,13 +7,18 @@
     const component = new Component();
     component.load();
     onDestroy(() => component.unload());
-    function render(el: HTMLElement, currentText: string) {
+    function renderInto(el: HTMLElement, md: string) {
         el.empty();
-        if (currentText) MarkdownRenderer.render(app, currentText, el, "/", component);
+        if (!md) return;
+        MarkdownRenderer.render(app, md, el, "/", component).catch((e) =>
+            console.error("Failed to render markdown description", e),
+        );
+    }
+    function render(el: HTMLElement, currentText: string) {
+        renderInto(el, currentText);
         return {
             update(newText: string) {
-                el.empty();
-                if (newText) MarkdownRenderer.render(app, newText, el, "/", component);
+                renderInto(el, newText);
             },
         };
     }

--- a/src/views/components/Form/ObsidianInputWrapper.svelte
+++ b/src/views/components/Form/ObsidianInputWrapper.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+    import { App } from "obsidian";
     import { readable } from "svelte/store";
+    import MarkdownDescription from "./MarkdownDescription.svelte";
     export let errors = readable([] as string[]);
     export let label = "";
     export let description = "";
     export let required = false;
     export let className = "";
+    export let app: App | undefined = undefined;
 </script>
 
 <!-- Trying to emulate native Obsidian settings -->
@@ -16,7 +19,11 @@
                 <span class="required">*</span>
             {/if}
         </div>
-        <div class="setting-item-description">{description}</div>
+        {#if app && description}
+            <MarkdownDescription {app} text={description} />
+        {:else}
+            <div class="setting-item-description">{description}</div>
+        {/if}
         {#each $errors as error}
             <div class="setting-item-description error">{error}</div>
         {/each}

--- a/src/views/components/Form/ObsidianSelect.svelte
+++ b/src/views/components/Form/ObsidianSelect.svelte
@@ -32,7 +32,7 @@
     }
 </script>
 
-<ObsidianInput {errors} label={field.label || field.name} description={field.description}>
+<ObsidianInput {errors} label={field.label || field.name} description={field.description} {app}>
     {#if input.source === "fixed"}
         <select bind:value={$value} class="dropdown">
             {#each input.options as option}

--- a/src/views/components/Form/ObsidianToggle.svelte
+++ b/src/views/components/Form/ObsidianToggle.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-    import { Setting, ToggleComponent } from "obsidian";
+    import { App, Setting, ToggleComponent } from "obsidian";
     import { FieldDefinition } from "src/core/formDefinition";
     import { FieldValue } from "src/store/formEngine";
     import { Writable } from "svelte/store";
     import { useSetting } from "./useObsidianSetting";
     export let field: FieldDefinition;
     export let value: Writable<FieldValue>;
+    export let app: App | undefined = undefined;
     let toggle_: ToggleComponent | undefined;
     function customizer(setting: Setting) {
         setting.addToggle((toggle) => {
@@ -25,6 +26,7 @@
         name: field.label || field.name,
         description: field.description || "",
         customizer,
+        app,
     }}
 >
     <span style="display: none;">dummy to prevent the setting from being the first child</span>

--- a/src/views/components/Form/RenderField.svelte
+++ b/src/views/components/Form/RenderField.svelte
@@ -47,6 +47,7 @@
         label={definition.label || definition.name}
         description={definition.description}
         errors={visibleError}
+        {app}
     >
         <input type="text" class="input" disabled placeholder="Condition error" />
     </ObsidianInputWrapper>
@@ -54,7 +55,7 @@
     {#if definition.input.type === "select"}
         <ObsidianSelect input={definition.input} field={definition} {value} {errors} {app} />
     {:else if definition.input.type === "toggle"}
-        <ObsidianToggle field={definition} {value} />
+        <ObsidianToggle field={definition} {value} {app} />
     {:else if definition.input.type === "folder"}
         <InputFolder
             field={definition}
@@ -74,7 +75,7 @@
     {:else if definition.input.type === "note"}
         <InputNote field={definition} input={definition.input} {value} {errors} {app} />
     {:else if definition.input.type === "textarea"}
-        <InputTextArea field={definition} {value} {errors} />
+        <InputTextArea field={definition} {value} {errors} {app} />
     {:else if definition.input.type === "markdown_block"}
         <MarkdownBlock field={definition.input} form={formEngine} {app} />
     {:else if definition.input.type === "document_block"}
@@ -82,6 +83,7 @@
         <ObsidianInputWrapper
             label={definition.label || definition.name}
             description={definition.description}
+            {app}
         >
             <DocumentBlock field={definition.input} form={formEngine} slot="info" {app} />
         </ObsidianInputWrapper>
@@ -91,6 +93,7 @@
             label={definition.label || definition.name}
             description={definition.description}
             required={definition.isRequired}
+            {app}
         >
             {#if $value == null || $value instanceof FileProxy}
                 {@const imageModel = makeImageInputModel({ fileService, input: definition.input })}
@@ -103,6 +106,7 @@
             label={definition.label || definition.name}
             description={definition.description}
             required={definition.isRequired}
+            {app}
         >
             {#if $value == null || $value instanceof FileProxy}
                 {@const fileModel = makeFileInputModel({ fileService, input: definition.input })}
@@ -115,6 +119,7 @@
             label={definition.label || definition.name}
             description={definition.description}
             required={definition.isRequired}
+            {app}
         >
             {#if definition.input.type === "multiselect"}
                 <MultiSelectField input={definition.input} {value} {errors} {app} />

--- a/src/views/components/Form/useObsidianSetting.ts
+++ b/src/views/components/Form/useObsidianSetting.ts
@@ -1,4 +1,4 @@
-import { Setting } from "obsidian";
+import { App, Component, MarkdownRenderer, Setting } from "obsidian";
 
 export function useSetting(
     element: HTMLElement,
@@ -6,10 +6,22 @@ export function useSetting(
         name: string;
         description: string;
         customizer?: (setting: Setting) => void;
+        app?: App;
     },
 ) {
-    new Setting(element)
+    const setting = new Setting(element)
         .setName(field.name)
         .setDesc(field.description)
         .then(field.customizer || (() => {}));
+    if (field.app && field.description) {
+        const component = new Component();
+        component.load();
+        setting.descEl.empty();
+        MarkdownRenderer.render(field.app, field.description, setting.descEl, "/", component);
+        return {
+            destroy() {
+                component.unload();
+            },
+        };
+    }
 }

--- a/src/views/components/Form/useObsidianSetting.ts
+++ b/src/views/components/Form/useObsidianSetting.ts
@@ -7,6 +7,16 @@ type SettingField = {
     app?: App;
 };
 
+function showRenderError(el: HTMLElement, err: unknown) {
+    el.empty();
+    console.error("Failed to render markdown description", err);
+    const msg = err instanceof Error ? err.message : String(err);
+    el.createDiv({
+        cls: "modal-form-description-error",
+        text: `Failed to render description: ${msg}`,
+    });
+}
+
 export function useSetting(element: HTMLElement, field: SettingField) {
     const setting = new Setting(element)
         .setName(field.name)
@@ -21,7 +31,7 @@ export function useSetting(element: HTMLElement, field: SettingField) {
             }
             setting.descEl.empty();
             MarkdownRenderer.render(next.app, next.description, setting.descEl, "/", component)
-                .catch((e) => console.error("Failed to render markdown description", e));
+                .catch((e) => showRenderError(setting.descEl, e));
         } else {
             setting.descEl.empty();
             setting.setDesc(next.description);

--- a/src/views/components/Form/useObsidianSetting.ts
+++ b/src/views/components/Form/useObsidianSetting.ts
@@ -1,27 +1,43 @@
 import { App, Component, MarkdownRenderer, Setting } from "obsidian";
 
-export function useSetting(
-    element: HTMLElement,
-    field: {
-        name: string;
-        description: string;
-        customizer?: (setting: Setting) => void;
-        app?: App;
-    },
-) {
+type SettingField = {
+    name: string;
+    description: string;
+    customizer?: (setting: Setting) => void;
+    app?: App;
+};
+
+export function useSetting(element: HTMLElement, field: SettingField) {
     const setting = new Setting(element)
         .setName(field.name)
         .setDesc(field.description)
         .then(field.customizer || (() => {}));
-    if (field.app && field.description) {
-        const component = new Component();
-        component.load();
-        setting.descEl.empty();
-        MarkdownRenderer.render(field.app, field.description, setting.descEl, "/", component);
-        return {
-            destroy() {
-                component.unload();
-            },
-        };
-    }
+    let component: Component | undefined;
+    const renderDescription = (next: SettingField) => {
+        if (next.app && next.description) {
+            if (!component) {
+                component = new Component();
+                component.load();
+            }
+            setting.descEl.empty();
+            MarkdownRenderer.render(next.app, next.description, setting.descEl, "/", component)
+                .catch((e) => console.error("Failed to render markdown description", e));
+        } else {
+            setting.descEl.empty();
+            setting.setDesc(next.description);
+        }
+    };
+    if (field.app && field.description) renderDescription(field);
+    return {
+        update(next: SettingField) {
+            if (next.name !== field.name) setting.setName(next.name);
+            if (next.description !== field.description || next.app !== field.app) {
+                renderDescription(next);
+            }
+            field = next;
+        },
+        destroy() {
+            component?.unload();
+        },
+    };
 }

--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,10 @@ If your plugin does not need CSS, delete this file.
 .modal-form .setting-item-description > p + p {
     margin-top: 0.25rem;
 }
+.modal-form .modal-form-description-error {
+    color: var(--text-error);
+    font-style: italic;
+}
 
 .modal-form {
     &.flex,

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,14 @@ If your plugin does not need CSS, delete this file.
     align-items: center;
 }
 
+/* Rendered markdown inside field descriptions: keep it visually compact. */
+.modal-form .setting-item-description > p {
+    margin: 0;
+}
+.modal-form .setting-item-description > p + p {
+    margin-top: 0.25rem;
+}
+
 .modal-form {
     &.flex,
     .flex {


### PR DESCRIPTION
## Summary

Field descriptions now render as markdown. Authors can drop links, wikilinks, bold/italic, and inline code into a description to point users at docs, format syntax references, or explain tricky inputs — the capability requested in #376.

Before, the description text was rendered as a plain string. Now it flows through Obsidian's `MarkdownRenderer`, so e.g. this description…

```
See the [Luxon format](https://moment.github.io/luxon/#/formatting) for supported tokens. Keep it **short** — e.g. `yyyy-MM-dd`.
```

…renders as a proper clickable link, bolded text, and code span inline with the field.

## Changes

- **New** `src/views/components/Form/MarkdownDescription.svelte` — small component that renders a markdown string into a `setting-item-description` div using `MarkdownRenderer.render`. It owns an Obsidian `Component` and unloads it in `onDestroy`, so event handlers on rendered content (e.g. internal link clicks) are cleaned up with the form modal.
- `ObsidianInputWrapper.svelte` accepts an optional `app` prop. When present **and** the description is non-empty, it renders markdown via `MarkdownDescription`; otherwise it falls back to the existing plain-text rendering.
- `useObsidianSetting.ts` (used by `toggle` and `folder`) accepts an optional `app` and renders markdown into the `Setting.descEl` when present, returning a `destroy` hook so the backing `Component` is unloaded with the element.
- `RenderField.svelte` plumbs `app` through all `ObsidianInputWrapper` usages, plus into `ObsidianToggle` and `InputTextArea`.
- `InputNote`, `InputDataview`, `ObsidianSelect`, `InputTextArea`, `InputFolder`, `ObsidianToggle` now pass `app` along to the wrapper / setting helper.
- `styles.css` zeroes the margin on rendered `<p>` elements inside `.setting-item-description` so the description lays out identically to a plain string (Obsidian's markdown output wraps short text in a `<p>`).

When `app` is `undefined` (defensive fallback), rendering falls back to the previous plain-text behaviour, so nothing breaks if a wrapper is instantiated in isolation.

## Test plan

- [x] `npm run check` (lint + svelte-check) — passes, only pre-existing warnings
- [x] `npm run test` — all 159 tests pass, 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) — passes, only pre-existing warnings
- [ ] Preview URL: open a form with a field whose description contains a link like `[docs](https://example.com)`, **bold**, or `` `code` ``, and confirm the rendered form shows clickable/styled markup beneath the field label
- [ ] Confirm a `toggle` or `folder` field with a markdown description also renders the markup (not only wrapper-based fields)

Closes #376


---
_Generated by [Claude Code](https://claude.ai/code/session_01P5UW1b6yKZtQ5BNZQYeXmj)_