### PR TITLE
feat: filter tag suggestions with include/exclude regex patterns

### DIFF
--- a/src/core/FormBuilder.test.ts
+++ b/src/core/FormBuilder.test.ts
@@ -146,6 +146,34 @@ describe("FormBuilder", () => {
             expect(form.fields[0]!.input).toEqual(expected);
         });
 
+        it("should create tag fields with include/exclude regex", () => {
+            const { builder } = createTestBuilder();
+            const form = builder("example-form")
+                .tag({
+                    name: "tags",
+                    include: "^Setting/",
+                    exclude: "^archive/",
+                })
+                .build();
+
+            expect(form.fields[0]!.input).toEqual({
+                type: "tag",
+                hidden: false,
+                include: "^Setting/",
+                exclude: "^archive/",
+            });
+        });
+
+        it("should create tag fields without include/exclude when not provided", () => {
+            const { builder } = createTestBuilder();
+            const form = builder("example-form").tag({ name: "tags" }).build();
+
+            expect(form.fields[0]!.input).toEqual({
+                type: "tag",
+                hidden: false,
+            });
+        });
+
         it("should create file fields with extensions", () => {
             const { builder } = createTestBuilder();
             const extensions = [".pdf"];

--- a/src/core/FormBuilder.ts
+++ b/src/core/FormBuilder.ts
@@ -88,8 +88,24 @@ export class FormBuilder implements FieldBuilderMethods {
     }: FieldArgs & { min?: number; max: number }) =>
         this.addField({ name, label, description, required }, { type: "slider", min: min ?? 0, max });
 
-    addTagField = ({ name, label, description, required, hidden }: FieldArgs & { hidden?: boolean }) =>
-        this.addField({ name, label, description, required }, { type: "tag", hidden: Boolean(hidden) });
+    addTagField = ({
+        name,
+        label,
+        description,
+        required,
+        hidden,
+        include,
+        exclude,
+    }: FieldArgs & { hidden?: boolean; include?: string; exclude?: string }) =>
+        this.addField(
+            { name, label, description, required },
+            {
+                type: "tag",
+                hidden: Boolean(hidden),
+                ...(include ? { include } : {}),
+                ...(exclude ? { exclude } : {}),
+            },
+        );
 
     addSelectField = ({
         name,

--- a/src/core/input/InputDefinitionSchema.test.ts
+++ b/src/core/input/InputDefinitionSchema.test.ts
@@ -1,0 +1,42 @@
+import { filterTags } from "./InputDefinitionSchema";
+
+describe("filterTags", () => {
+    const tags = ["Setting/Event", "Setting/Theme", "Project/Alpha", "archive/2024"];
+
+    it("returns all tags when neither include nor exclude is set", () => {
+        expect(filterTags(tags, {})).toEqual(tags);
+    });
+
+    it("keeps only tags matching the include regex", () => {
+        expect(filterTags(tags, { include: "^Setting/" })).toEqual([
+            "Setting/Event",
+            "Setting/Theme",
+        ]);
+    });
+
+    it("drops tags matching the exclude regex", () => {
+        expect(filterTags(tags, { exclude: "^archive/" })).toEqual([
+            "Setting/Event",
+            "Setting/Theme",
+            "Project/Alpha",
+        ]);
+    });
+
+    it("combines include and exclude — include first, then exclude", () => {
+        expect(
+            filterTags(tags, { include: "^Setting/", exclude: "Theme$" }),
+        ).toEqual(["Setting/Event"]);
+    });
+
+    it("treats an invalid include regex as no filter (fail-safe)", () => {
+        expect(filterTags(tags, { include: "[unterminated" })).toEqual(tags);
+    });
+
+    it("treats an invalid exclude regex as no filter (fail-safe)", () => {
+        expect(filterTags(tags, { exclude: "[unterminated" })).toEqual(tags);
+    });
+
+    it("treats empty strings as no filter", () => {
+        expect(filterTags(tags, { include: "", exclude: "" })).toEqual(tags);
+    });
+});

--- a/src/core/input/InputDefinitionSchema.ts
+++ b/src/core/input/InputDefinitionSchema.ts
@@ -55,9 +55,35 @@ export const SelectFromNotesSchema = object({
 });
 export const InputTagSchema = object({
     type: literal("tag"),
-    exclude: optional(string()), // This should be a regex string
+    include: optional(string()), // Regex string. When set, only tags matching it are suggested.
+    exclude: optional(string()), // Regex string. When set, tags matching it are filtered out.
     hidden: optional(boolean(), false),
 });
+
+/**
+ * Filters a list of tag names according to the `include`/`exclude` regex
+ * patterns declared on a tag input. Invalid regex patterns are ignored (the
+ * full list is returned) so a typo in the form definition doesn't blow up the
+ * form at render time.
+ */
+export function filterTags(tags: string[], input: { include?: string; exclude?: string }): string[] {
+    const includeRe = safeRegex(input.include);
+    const excludeRe = safeRegex(input.exclude);
+    return tags.filter((tag) => {
+        if (includeRe && !includeRe.test(tag)) return false;
+        if (excludeRe && excludeRe.test(tag)) return false;
+        return true;
+    });
+}
+
+function safeRegex(pattern: string | undefined): RegExp | undefined {
+    if (!pattern) return undefined;
+    try {
+        return new RegExp(pattern);
+    } catch {
+        return undefined;
+    }
+}
 export const InputSliderSchema = object({
     type: literal("slider"),
     min: number(),

--- a/src/views/FormBuilder.svelte
+++ b/src/views/FormBuilder.svelte
@@ -21,6 +21,7 @@
     import InputFolder from "./components/InputBuilderFolder.svelte";
     import InputBuilderImage from "./components/InputBuilderImage.svelte";
     import InputBuilderSelect from "./components/InputBuilderSelect.svelte";
+    import InputBuilderTag from "./components/InputBuilderTag.svelte";
     import Tabs from "./components/Tabs.svelte";
     import TemplateEditor from "./components/TemplateEditor.svelte";
     import Toggle from "./components/Toggle.svelte";
@@ -372,7 +373,14 @@
                                     notifyChange={onChange}
                                     {app}
                                 />
-                            {:else if field.input.type === "number" || field.input.type === "email" || field.input.type === "tel" || field.input.type === "date" || field.input.type === "time" || field.input.type === "datetime" || field.input.type === "toggle" || field.input.type === "textarea" || field.input.type === "text" || field.input.type === "tag"}
+                            {:else if field.input.type === "tag"}
+                                <InputBuilderTag
+                                    {index}
+                                    bind:include={field.input.include}
+                                    bind:exclude={field.input.exclude}
+                                    notifyChange={onChange}
+                                />
+                            {:else if field.input.type === "number" || field.input.type === "email" || field.input.type === "tel" || field.input.type === "date" || field.input.type === "time" || field.input.type === "datetime" || field.input.type === "toggle" || field.input.type === "textarea" || field.input.type === "text"}
                                 <!-- * empty  -->
                             {:else}
                                 {absurd(field.input.type)}

--- a/src/views/components/InputBuilderTag.svelte
+++ b/src/views/components/InputBuilderTag.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import FormRow from "./FormRow.svelte";
+
+    export let index: number;
+    export let include: string | undefined;
+    export let exclude: string | undefined;
+    export let notifyChange: () => void;
+
+    $: includeId = `tag_include_${index}`;
+    $: excludeId = `tag_exclude_${index}`;
+    $: includeError = checkRegex(include);
+    $: excludeError = checkRegex(exclude);
+
+    function checkRegex(pattern: string | undefined): string {
+        if (!pattern) return "";
+        try {
+            new RegExp(pattern);
+            return "";
+        } catch (e) {
+            return e instanceof Error ? e.message : "Invalid regex";
+        }
+    }
+
+    function onIncludeChange(e: Event) {
+        const v = (e.target as HTMLInputElement).value;
+        include = v.trim() || undefined;
+        notifyChange();
+    }
+
+    function onExcludeChange(e: Event) {
+        const v = (e.target as HTMLInputElement).value;
+        exclude = v.trim() || undefined;
+        notifyChange();
+    }
+</script>
+
+<div class="flex column gap1 full-width">
+    <FormRow
+        label="Include pattern"
+        id={includeId}
+        tooltip="Regular expression. If set, only tags matching this pattern will be suggested. Example: ^Setting/ only allows tags starting with 'Setting/'."
+    >
+        <input
+            id={includeId}
+            type="text"
+            value={include ?? ""}
+            on:input={onIncludeChange}
+            placeholder="^Setting/"
+        />
+        {#if includeError}
+            <div class="modal-form-error-message">{includeError}</div>
+        {/if}
+    </FormRow>
+    <FormRow
+        label="Exclude pattern"
+        id={excludeId}
+        tooltip="Regular expression. If set, tags matching this pattern will be hidden from suggestions."
+    >
+        <input
+            id={excludeId}
+            type="text"
+            value={exclude ?? ""}
+            on:input={onExcludeChange}
+            placeholder="^archive/"
+        />
+        {#if excludeError}
+            <div class="modal-form-error-message">{excludeError}</div>
+        {/if}
+    </FormRow>
+</div>
+
+<style>
+    .full-width {
+        width: 100%;
+    }
+</style>

--- a/src/views/components/MultiSelectModel.ts
+++ b/src/views/components/MultiSelectModel.ts
@@ -1,7 +1,12 @@
 import { A, pipe } from "@std";
 import { absurd } from "fp-ts/function";
 import { App } from "obsidian";
-import { getMultiselectNoteFolders, inputTag, multiselect } from "src/core/input/InputDefinitionSchema";
+import {
+    filterTags,
+    getMultiselectNoteFolders,
+    inputTag,
+    multiselect,
+} from "src/core/input/InputDefinitionSchema";
 import { executeSandboxedDvQuery, sandboxedDvQuery } from "src/suggesters/SafeDataviewQuery";
 import { StringSuggest } from "src/suggesters/StringSuggest";
 import { FileSuggest } from "src/suggesters/suggestFile";
@@ -84,11 +89,10 @@ export function MultiSelectTags(
     app: App,
     values: Writable<string[] | undefined>,
 ): MultiSelectModel {
-    const remainingOptions = new Set(
-        Object.keys(app.metadataCache.getTags()).map(
-            (tag) => tag.slice(1) /** remove the leading # */,
-        ),
+    const allTags = Object.keys(app.metadataCache.getTags()).map(
+        (tag) => tag.slice(1) /** remove the leading # */,
     );
+    const remainingOptions = new Set(filterTags(allTags, fieldInput));
     return {
         createInput(element: HTMLInputElement) {
             new StringSuggest(
@@ -96,10 +100,9 @@ export function MultiSelectTags(
                 remainingOptions,
                 (selected) => {
                     remainingOptions.delete(selected);
-                    values.update((x) => {
-                        console.log(x);
-                        return x == undefined ? [selected] : [...x, selected];
-                    });
+                    values.update((x) =>
+                        x == undefined ? [selected] : [...x, selected],
+                    );
                 },
                 app,
                 true,


### PR DESCRIPTION
## Summary

Adds optional `include` and `exclude` regex patterns to **tag** inputs so authors can restrict the tag suggester to a prefix/namespace (e.g. `^Setting/`) or hide unwanted tags (e.g. `^archive/`).

The `exclude` field already existed in `InputTagSchema` but was never wired to the suggester — this PR finishes that feature and adds `include` alongside, addressing the use-case in #406 where a user wanted to restrict the tag suggester to a specific prefix like `#Setting/Event/`, `#Setting/Theme/`, etc.

### Before vs. after

Before, a tag field suggested every tag in the vault regardless of the `exclude` value in the form definition. Now:

```json
{
    "name": "tags",
    "input": {
        "type": "tag",
        "include": "^Setting/",
        "exclude": "Deprecated"
    }
}
```

…suggests only tags that start with `Setting/` and aren't marked `Deprecated`.

## Changes

- **`src/core/input/InputDefinitionSchema.ts`** — adds `include` to `InputTagSchema` and a pure `filterTags(tags, { include, exclude })` helper. Invalid regex patterns are silently ignored (fail-open) so a typo doesn't break form rendering.
- **`src/views/components/MultiSelectModel.ts`** — `MultiSelectTags` now runs the vault's tags through `filterTags` before seeding the suggester. A stale `console.log(x)` inside the update callback was removed at the same time.
- **`src/core/FormBuilder.ts`** — `addTagField` accepts optional `include`/`exclude` so the fluent API matches the schema.
- **`src/views/components/InputBuilderTag.svelte`** (new) — small builder UI with two text inputs for the regex patterns, plus inline validation that shows the `new RegExp()` error message when the pattern is malformed. Wired into `FormBuilder.svelte` in place of the previous empty `tag` branch.
- Tests in `src/core/input/InputDefinitionSchema.test.ts` cover include-only, exclude-only, include+exclude, invalid regex fail-open, and empty-string behaviour. A new `FormBuilder.test.ts` case covers the builder accepting and dropping `include`/`exclude`.

## Test plan

- [x] `npm run test` — all 168 tests pass, 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) passes — only pre-existing warnings (Toggle a11y, unused `.clear-button` CSS)
- [ ] Preview URL: open the form builder, add a tag field, type `^Setting/` into the Include pattern input, and confirm the suggester only offers tags under that prefix
- [ ] Confirm an invalid regex like `[unterminated` shows the inline error message below the input and the form still renders (suggester falls back to the unfiltered list)

Closes #406

https://claude.ai/code/session_01NgTiWhKJ4bDZGHpJ48romv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgTiWhKJ4bDZGHpJ48romv)_