### PR TITLE
feat: add step option to slider input

### DIFF
--- a/src/core/FormBuilder.test.ts
+++ b/src/core/FormBuilder.test.ts
@@ -94,6 +94,29 @@ describe("FormBuilder", () => {
             expect(form.fields[0]!.input).toEqual(expected);
         });
 
+        it("should create slider fields with a custom step", () => {
+            const { builder } = createTestBuilder();
+            const form = builder("example-form")
+                .slider({ name: "rating", min: 0, max: 5, step: 0.5 })
+                .build();
+
+            const expected = {
+                type: "slider" as const,
+                min: 0,
+                max: 5,
+                step: 0.5,
+            };
+
+            expect(form.fields[0]!.input).toEqual(expected);
+        });
+
+        it("should omit step from slider input when not provided", () => {
+            const { builder } = createTestBuilder();
+            const form = builder("example-form").slider({ name: "rating", max: 10 }).build();
+
+            expect(form.fields[0]!.input).not.toHaveProperty("step");
+        });
+
         it("should create select fields with options", () => {
             const { builder } = createTestBuilder();
             const options = ["Low", "Medium", "High"];

--- a/src/core/FormBuilder.ts
+++ b/src/core/FormBuilder.ts
@@ -85,8 +85,12 @@ export class FormBuilder implements FieldBuilderMethods {
         required,
         min,
         max,
-    }: FieldArgs & { min?: number; max: number }) =>
-        this.addField({ name, label, description, required }, { type: "slider", min: min ?? 0, max });
+        step,
+    }: FieldArgs & { min?: number; max: number; step?: number }) =>
+        this.addField(
+            { name, label, description, required },
+            { type: "slider", min: min ?? 0, max, ...(step !== undefined ? { step } : {}) },
+        );
 
     addTagField = ({ name, label, description, required, hidden }: FieldArgs & { hidden?: boolean }) =>
         this.addField({ name, label, description, required }, { type: "tag", hidden: Boolean(hidden) });

--- a/src/core/formDefinition.test.ts
+++ b/src/core/formDefinition.test.ts
@@ -67,10 +67,16 @@ describe("isInputSlider", () => {
         expect(isInputSlider({ type: "slider", min: 0, max: 10 })).toBe(true);
     });
 
+    it("should accept an optional numeric step", () => {
+        expect(isInputSlider({ type: "slider", min: 0, max: 10, step: 0.5 })).toBe(true);
+        expect(isInputSlider({ type: "slider", min: 0, max: 100, step: 5 })).toBe(true);
+    });
+
     it("should return false for invalid inputSlider objects", () => {
         expect(isInputSlider({ type: "slider" })).toBe(false);
         expect(isInputSlider({ type: "slider", min: "0", max: 10 })).toBe(false);
         expect(isInputSlider({ type: "select", min: 0, max: 10 })).toBe(false);
+        expect(isInputSlider({ type: "slider", min: 0, max: 10, step: "0.5" })).toBe(false);
     });
 });
 

--- a/src/core/input/InputDefinitionSchema.ts
+++ b/src/core/input/InputDefinitionSchema.ts
@@ -62,6 +62,7 @@ export const InputSliderSchema = object({
     type: literal("slider"),
     min: number(),
     max: number(),
+    step: optional(number()),
 });
 export const InputNoteFromFolderSchema = object({
     type: literal("note"),

--- a/src/views/FormBuilder.svelte
+++ b/src/views/FormBuilder.svelte
@@ -310,6 +310,7 @@
                             {:else if field.input.type === "slider"}
                                 {@const min_id = `min_${index}`}
                                 {@const max_id = `max_${index}`}
+                                {@const step_id = `step_${index}`}
                                 <div class="flex column gap1">
                                     <label for={min_id}>Min</label>
                                     <input
@@ -326,6 +327,17 @@
                                         bind:value={field.input.max}
                                         placeholder="10"
                                         id={max_id}
+                                    />
+                                </div>
+                                <div class="flex column gap1">
+                                    <label for={step_id}>Step</label>
+                                    <input
+                                        type="number"
+                                        bind:value={field.input.step}
+                                        placeholder="1"
+                                        step="any"
+                                        min="0"
+                                        id={step_id}
                                     />
                                 </div>
                             {:else if field.input.type === "note"}

--- a/src/views/components/Form/inputSlider.svelte
+++ b/src/views/components/Form/inputSlider.svelte
@@ -11,7 +11,14 @@
     <span>
         {$value === undefined ? input.min : $value}
     </span>
-    <input type="range" bind:value={$value} class="slider" min={input.min} max={input.max} />
+    <input
+        type="range"
+        bind:value={$value}
+        class="slider"
+        min={input.min}
+        max={input.max}
+        step={input.step ?? 1}
+    />
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

Slider fields could only step in increments of 1, because the only knobs exposed were `min` and `max`. This adds an optional `step` to `slider`, so authors can build half-point ratings, decimal sliders (`step: 0.1`), or coarse jumps (`step: 5`).

### Before vs. after

Before:

```json
{ "type": "slider", "min": 0, "max": 5 }
```

…always moved in whole units. Now:

```json
{ "type": "slider", "min": 0, "max": 5, "step": 0.5 }
```

…produces a slider that snaps to 0, 0.5, 1, 1.5 … 5.

## Changes

- **`src/core/input/InputDefinitionSchema.ts`** — `InputSliderSchema` gains an optional `step: number`. Existing slider definitions remain valid because the field is optional.
- **`src/views/components/Form/inputSlider.svelte`** — passes `input.step` to the `<input type="range">` element, defaulting to `1` when unset. Existing forms render identically.
- **`src/views/FormBuilder.svelte`** — adds a third "Step" number input next to Min/Max in the form builder, with `step="any"` and `min="0"` so the author can type fractional values like `0.5`.
- **`src/core/FormBuilder.ts`** — `addSliderField` accepts an optional `step` and only sets it on the resulting input when the caller supplies one (so the field stays clean when omitted).
- Tests:
  - `src/core/FormBuilder.test.ts` — covers building a slider with `step: 0.5` and confirms `step` is omitted when not passed.
  - `src/core/formDefinition.test.ts` — `isInputSlider` now verifies the optional step is accepted (numeric) and rejected (non-numeric).

## Test plan

- [x] `npm run test` — all 162 tests pass (was 159, +3 new), 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) passes — only pre-existing warnings (Toggle a11y, unused `.clear-button` CSS)
- [ ] Preview URL: open the form builder, add a slider field, set Min=0, Max=5, Step=0.5; preview the form and confirm the slider snaps in 0.5 increments and the value display shows the fractional value
- [ ] Confirm an existing slider (no step) still renders and steps by 1 as before


---
_Generated by [Claude Code](https://claude.ai/code/session_016zSrDPJGebejgLr6Bguvm7)_