### PR TITLE
feat: add `link` template transformation for wikilink output

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -86,6 +86,20 @@ The following transformations can be applied to variables:
      {{ name | stringify }}
      ```
 
+5. **`link`**: Wraps the variable's value in Obsidian wikilink brackets `[[ ]]`.
+   When applied to a multi-value field (like `multiselect`), each entry is
+   wrapped individually and the results are joined with `, `.
+   - Usage:
+
+     ```plaintext
+     {{ person | link }}
+     ```
+
+     With `person = "Jane Doe"` produces `[[Jane Doe]]`.
+
+     With `attendees = ["Alice", "Bob"]` and template `{{ attendees | link }}`
+     produces `[[Alice]], [[Bob]]`.
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -178,6 +178,42 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of('Hello, "John"!'));
     });
 
+    it("Should execute a template with link transformation on a string value", () => {
+        const template = "Meeting with {{ name | link }} today.";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { name: "John Doe" }),
+            ),
+        );
+        expect(result).toEqual(E.of("Meeting with [[John Doe]] today."));
+    });
+
+    it("Should execute a template with link transformation on an array value", () => {
+        const template = "Attendees: {{ people | link }}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { people: ["Alice", "Bob"] }),
+            ),
+        );
+        expect(result).toEqual(E.of("Attendees: [[Alice]], [[Bob]]"));
+    });
+
+    it("link transformation should drop empty entries from an array", () => {
+        const template = "{{ people | link }}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { people: ["Alice", "", "Bob"] }),
+            ),
+        );
+        expect(result).toEqual(E.of("[[Alice]], [[Bob]]"));
+    });
+
     it("Spaces around transformations should be ignored", () => {
         const template = "Hello, {{name | stringify }}!";
         const parsed = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -236,6 +236,10 @@ function asFrontmatterString(data: Record<string, unknown>) {
         );
 }
 
+function toWikilink(s: string): string {
+    return `[[${s}]]`;
+}
+
 function executeTransformation(
     transformation: Transformations | undefined,
 ): (value: Val) => string {
@@ -252,6 +256,14 @@ function executeTransformation(
                 return JSON.stringify(value);
             case "trim":
                 return String(value).trim();
+            case "link":
+                if (Array.isArray(value)) {
+                    return value
+                        .filter((v) => String(v).length > 0)
+                        .map((v) => toWikilink(String(v)))
+                        .join(", ");
+                }
+                return toWikilink(String(value));
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -22,6 +22,7 @@ export const transformations = union([
     literal("lower"),
     literal("trim"),
     literal("stringify"),
+    literal("link"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds a new `link` transformation to the template system, alongside the existing `upper`, `lower`, `trim`, and `stringify`. It wraps values in Obsidian wikilink brackets `[[ ]]`, which is a common need when a form field references existing notes — for example, a multiselect field sourced from a Notes folder.

### Before vs. after

Before, if you had a multiselect field `attendees` with `["Alice", "Bob"]` selected, the only way to get `[[Alice]], [[Bob]]` in your template output was to post-process via Templater (or hand-write the brackets in a custom string). Now you can write:

```plaintext
Attendees: {{ attendees | link }}
```

…and get `Attendees: [[Alice]], [[Bob]]` directly.

For a single-value field:

```plaintext
Meeting with {{ person | link }} today.
```

…with `person = "Jane Doe"` produces `Meeting with [[Jane Doe]] today.`

This addresses the recurring request in #418 (and similar threads) where users want a notes-multiselect to render as wikilinks without writing a transform step themselves.

## Changes

- **`src/core/template/templateSchema.ts`** — adds `literal("link")` to the `transformations` valibot union so the parser accepts `| link` in templates.
- **`src/core/template/templateParser.ts`** — handles the new `link` case in `executeTransformation`. For a string value it returns `[[value]]`; for an array it filters out empty entries and joins each wrapped entry with `, ` (avoids producing `[[]]` from empty multiselect slots).
- **`src/core/template/templateParser.test.ts`** — three new tests covering the string case, the array case, and the empty-entry-dropping behaviour.
- **`docs/templates.md`** — documents the new transformation alongside the existing four, with examples for both single-value and array-value usage.

Existing tests remain unchanged; no behaviour is altered for templates that don't use `| link`.

## Test plan

- [x] `npm run test` — all 162 tests pass (was 159, +3 new), 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) passes — only pre-existing warnings (Toggle a11y, unused `.clear-button` CSS, unused Toggle import)
- [ ] Preview URL: open a form with a multiselect sourced from a Notes folder, set the template to `Attendees: {{ fieldName | link }}` and confirm the rendered output contains the values wrapped as Obsidian wikilinks
- [ ] Preview URL: confirm a string field with `{{ name | link }}` renders as `[[name value]]`
- [ ] Preview URL: confirm existing transformations (`upper`, `lower`, `trim`, `stringify`) still work unchanged

https://claude.ai/code/session_01TexR9NfzdJkEUoMkHgzztq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TexR9NfzdJkEUoMkHgzztq)_