### PR TITLE
feat: render array values as wikilinks via ResultValue.link

### DIFF
--- a/docs/ResultValue.md
+++ b/docs/ResultValue.md
@@ -116,7 +116,8 @@ All of this shortcuts are able to handle single values and lists, so you can use
 ### `link` method
 
 The `link` method is a convenience method to render the value as a markdown link.
-If the value is a string, it will be rendered as a markdown link.
+If the value is a string, it will be rendered as a wikilink.
+If the value is an array (e.g. a multiselect or tag field), each non-empty entry is wrapped in wikilink brackets and the result is joined with `, `.
 If the value is a FileProxy (right now just used for images), it will be rendered as an embedded link.
 Any other type of value will be rendered as an empty string.
 
@@ -125,5 +126,11 @@ Any other type of value will be rendered as an empty string.
 ```
 
 You can also use the shorthand way of accessing values directly from the form result object, like `result.myField.link`.
+
+For an array field like a multiselect of notes, `result.attendees.link` produces `[[Alice]], [[Bob]]`. If you'd rather render each link on its own line (e.g. a YAML list), combine `map` with `bullets`:
+
+```typescript
+<% result.getValue('attendees').map((arr) => arr.map((v) => `[[${v}]]`)).bullets %>
+```
 
 Take a look at the example vault to see how it is used.

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -284,6 +284,33 @@ describe("ResultValue", () => {
             expect(trimmed.toString()).toEqual("test");
         });
     })
+    describe("link", () => {
+        it("should wrap a string value in wikilink brackets", () => {
+            const resultValue = ResultValue.from("Jane Doe", "person");
+
+            expect(resultValue.link).toEqual("[[Jane Doe]]");
+        });
+        it("should wrap each entry of an array in wikilink brackets and join them with ', '", () => {
+            const resultValue = ResultValue.from(["Alice", "Bob"], "attendees");
+
+            expect(resultValue.link).toEqual("[[Alice]], [[Bob]]");
+        });
+        it("should drop empty entries from an array so the output never contains '[[]]'", () => {
+            const resultValue = ResultValue.from(["Alice", "", "Bob"], "attendees");
+
+            expect(resultValue.link).toEqual("[[Alice]], [[Bob]]");
+        });
+        it("should return an empty string for an empty array", () => {
+            const resultValue = ResultValue.from([], "attendees");
+
+            expect(resultValue.link).toEqual("");
+        });
+        it("should return an empty string for non-string, non-array, non-FileProxy values", () => {
+            expect(ResultValue.from(42, "n").link).toEqual("");
+            expect(ResultValue.from(true, "b").link).toEqual("");
+            expect(ResultValue.from(null, "x").link).toEqual("");
+        });
+    });
     describe("chaining shortcuts", () => {
         it("should be possible to chain upper, lower and trim", () => {
             // Arrange

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -203,18 +203,27 @@ export class ResultValue<T = unknown> {
 
     /**
      * renders the value as a markdown link.
-     * If the value is a string, it will be rendered as a markdown link.
+     * If the value is a string, it will be rendered as a wikilink.
+     * If the value is an array of strings (e.g. a multiselect or tag field),
+     * each non-empty string is wrapped in wikilink brackets and the result is
+     * joined with ", " (matches the joining used by `toString`).
      * If the value is a FileProxy (right now just used for images), it will be rendered as an embedded link.
      * Any other type of value will be rendered as an empty string.
      */
     get link() {
-        switch (true) {
-            case typeof this.value === "string":
-                return `[[${this.value}]]`;
-            case this.value instanceof FileProxy:
-                return `![[${this.value.path}]]`;
-            default:
-                return "";
+        const value = this.value;
+        if (typeof value === "string") {
+            return `[[${value}]]`;
         }
+        if (value instanceof FileProxy) {
+            return `![[${value.path}]]`;
+        }
+        if (Array.isArray(value)) {
+            return value
+                .filter((v): v is string => typeof v === "string" && v.length > 0)
+                .map((v) => `[[${v}]]`)
+                .join(", ");
+        }
+        return "";
     }
 }


### PR DESCRIPTION
## Summary

The proxy/getter API on form results — `result.fieldName.link` — already wraps strings as `[[value]]` and `FileProxy`s as `![[path]]`, but it returned an empty string for arrays. So the very common case of a multiselect-of-notes (the request in #418) couldn't render through the convenient `result.attendees.link` shorthand and forced users into a manual `.map(arr => arr.map(...))` workaround.

This PR fills that gap: array values are now wrapped entry-by-entry and joined with `", "`, matching how `toString()` already serializes arrays in `ResultValue`.

### Before vs. after

Before, given a multiselect `attendees` with `["Alice", "Bob"]`:

```typescript
<% result.attendees.link %>
```

…rendered nothing. Now it renders:

```
[[Alice]], [[Bob]]
```

Empty entries are filtered out, so a half-filled multiselect doesn't produce stray `[[]]` tokens.

This is a separate code path from PR #471 (which adds the `| link` transformation to the parser-ts template syntax). #471 covers `{{ attendees | link }}`; this PR covers `result.attendees.link` / `result.getValue('attendees').link`. Both are useful and complementary — the proxy form is what users reach for in Templater (`<% result.attendees.link %>`) and from JS callers.

For per-line bullet output (e.g. a YAML list), `map` + `bullets` still composes cleanly — the docs now show that pattern.

## Changes

- **`src/core/ResultValue.ts`** — `link` getter handles `Array.isArray(value)`: filters non-string and empty entries, wraps each remaining string in `[[ ]]`, joins with `", "`. Existing string and `FileProxy` branches are unchanged.
- **`src/core/ResultValue.test.ts`** — adds a `describe("link", …)` block (5 new tests): single string, array of strings, dropping empty array entries, empty array → `""`, and unsupported types (`number`, `boolean`, `null`) returning `""`.
- **`docs/ResultValue.md`** — describes the new array behaviour and shows the `map`+`bullets` recipe for users who want one wikilink per line.

## Test plan

- [x] `npm run test` — 164 tests pass (was 159, +5 new), 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) — `svelte-check found 0 errors`, only the 5 pre-existing warnings (Toggle a11y x2, unused `.clear-button`/`.clear-button:hover` CSS)
- [ ] Preview URL: open a form with a multiselect-of-notes field `attendees`, return `result.asString('Attendees: {{attendees}}')` … actually verify via `<% result.attendees.link %>` in a Templater snippet — expect `[[Person 1]], [[Person 2]]`
- [ ] Preview URL: confirm `<% result.singleField.link %>` on a plain text field still renders `[[value]]` (no regression)
- [ ] Preview URL: confirm an empty multiselect yields no output rather than `[[]]`

Refs #418

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF8KPvzjVPwo8vNbziMenn)_