### PR TITLE
feat: add `bullets` template transformation

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -86,6 +86,22 @@ The following transformations can be applied to variables:
      {{ name | stringify }}
      ```
 
+5. **`bullets`**: Renders the variable's value as a markdown bullet list. For array values (e.g. multiselect fields), each entry becomes its own bullet, and empty entries are dropped. For single values, a one-item list is produced.
+   - Usage:
+
+     ```plaintext
+     Attendees:
+     {{ attendees | bullets }}
+     ```
+
+   - Example output for `attendees = ["Alice", "Bob"]`:
+
+     ```plaintext
+     Attendees:
+     - Alice
+     - Bob
+     ```
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -167,6 +167,40 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("Hello, John!"));
     });
 
+    it("Should execute a template with bullets transformation on a single value", () => {
+        const template = "Tags:\n{{tag|bullets}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { tag: "obsidian" })),
+        );
+        expect(result).toEqual(E.of("Tags:\n- obsidian"));
+    });
+
+    it("Should execute a template with bullets transformation on an array", () => {
+        const template = "Attendees:\n{{attendees|bullets}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { attendees: ["Alice", "Bob", "Carol"] }),
+            ),
+        );
+        expect(result).toEqual(E.of("Attendees:\n- Alice\n- Bob\n- Carol"));
+    });
+
+    it("Should drop empty entries from bullets transformation", () => {
+        const template = "{{tags|bullets}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { tags: ["one", "", "two"] }),
+            ),
+        );
+        expect(result).toEqual(E.of("- one\n- two"));
+    });
+
     it("Should execute a template with stringify transformations", () => {
         const template = "Hello, {{name|stringify}}!";
         const parsed = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -236,6 +236,16 @@ function asFrontmatterString(data: Record<string, unknown>) {
         );
 }
 
+function toBullets(value: Val): string {
+    if (Array.isArray(value)) {
+        return value
+            .filter((entry) => entry !== "" && entry != null)
+            .map((entry) => `- ${entry}`)
+            .join("\n");
+    }
+    return `- ${String(value)}`;
+}
+
 function executeTransformation(
     transformation: Transformations | undefined,
 ): (value: Val) => string {
@@ -252,6 +262,8 @@ function executeTransformation(
                 return JSON.stringify(value);
             case "trim":
                 return String(value).trim();
+            case "bullets":
+                return toBullets(value);
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -22,6 +22,7 @@ export const transformations = union([
     literal("lower"),
     literal("trim"),
     literal("stringify"),
+    literal("bullets"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds a new `bullets` transformation to the template system, alongside the existing `upper`, `lower`, `trim`, and `stringify`. It renders the variable's value as a markdown bullet list — particularly useful for array-valued fields like a multiselect.

The capability already exists on the proxy/getter API as `result.field.bullets`, but until now there was no equivalent in the `{{ field | transformation }}` template syntax. Templates that wanted a bullet list of selected values had to fall back to writing the values inline and post-processing through Templater. This closes that gap.

### Before vs. after

Before, given a multiselect `attendees` with `["Alice", "Bob", "Carol"]`:

```plaintext
Attendees:
{{ attendees }}
```

…rendered:

```plaintext
Attendees:
Alice, Bob, Carol
```

Now, with the new transformation:

```plaintext
Attendees:
{{ attendees | bullets }}
```

…renders:

```plaintext
Attendees:
- Alice
- Bob
- Carol
```

For a single value, the transformation still produces a one-item bullet list (`{{ status | bullets }}` with `status = "draft"` → `- draft`), so authors don't need a separate template branch for the "only one value selected" case.

Empty entries (`""`, `null`) are filtered out, so a half-filled multiselect doesn't produce stray `- ` markers.

This pairs naturally with the existing transformations and is consistent with the `bullets`/`toBulletList` API already exposed on `ResultValue` (so `{{ tags | bullets }}` and `result.tags.bullets` now produce the same output).

## Changes

- **`src/core/template/templateSchema.ts`** — adds `literal("bullets")` to the `transformations` valibot union so the parser accepts `| bullets`.
- **`src/core/template/templateParser.ts`** — adds a small `toBullets(value)` helper and the `bullets` case in `executeTransformation`. Arrays are filtered (drop empty/`null` entries) and joined with `\n`; non-arrays produce a one-item list.
- **`src/core/template/templateParser.test.ts`** — three new tests: single-value case, array case, and empty-entry-dropping behaviour.
- **`docs/templates.md`** — documents the new transformation alongside the existing four, with example input/output.

Existing tests remain unchanged; templates that don't use `| bullets` are unaffected.

## Test plan

- [x] `npm run test` — 162 tests pass (was 159, +3 new), 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) — `svelte-check found 0 errors`, only the 5 pre-existing warnings (Toggle a11y, unused `.clear-button`/`.clear-button:hover` CSS, unused Toggle import)
- [ ] Preview URL: open a form with a multiselect field `attendees`, set the template to `Attendees:\n{{ attendees | bullets }}` and confirm the rendered output is one bullet per selected value
- [ ] Preview URL: confirm a string field with `{{ name | bullets }}` renders as `- value`
- [ ] Preview URL: confirm an empty multiselect produces no stray `- ` lines
- [ ] Preview URL: confirm existing transformations (`upper`, `lower`, `trim`, `stringify`) still work unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01EDifRoAV9eCiRJoYZen3eY)_