### PR TITLE
feat: add `count` template transformation

### DIFF
--- a/docs/ResultValue.md
+++ b/docs/ResultValue.md
@@ -113,6 +113,21 @@ The most common use is probably just to use one of them, like `trimmed` or `uppe
 
 All of this shortcuts are able to handle single values and lists, so you can use them with any value.
 
+### `count` shortcut
+
+The `count` shortcut returns the number of items represented by the value as a string. It's particularly useful for rendering "X items selected" snippets in templates, but works on any value type.
+
+- Arrays return their length.
+- Strings return their character length.
+- `null` and `undefined` return `0`.
+- Any other value returns `1`.
+
+```typescript
+You picked <% result.getValue('tags').count %> tags.
+```
+
+If the value of `tags` is `["work", "urgent"]`, the above will print `You picked 2 tags.`.
+
 ### `link` method
 
 The `link` method is a convenience method to render the value as a markdown link.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -86,6 +86,15 @@ The following transformations can be applied to variables:
      {{ name | stringify }}
      ```
 
+5. **`count`**: Returns the number of items represented by the value.
+   - Arrays return their length, strings return their character length, and any other value returns `1`.
+   - Useful for rendering things like "X items selected" from a multiselect.
+   - Usage:
+
+     ```plaintext
+     You picked {{ tags | count }} tags.
+     ```
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -284,6 +284,28 @@ describe("ResultValue", () => {
             expect(trimmed.toString()).toEqual("test");
         });
     })
+    describe("count", () => {
+        it("returns the array length for array values", () => {
+            const resultValue = ResultValue.from(["foo", "bar", "baz"], "Test");
+            expect(resultValue.count).toEqual("3");
+        });
+        it("returns 0 for an empty array", () => {
+            const resultValue = ResultValue.from([], "Test");
+            expect(resultValue.count).toEqual("0");
+        });
+        it("returns the character length for string values", () => {
+            const resultValue = ResultValue.from("hello", "Test");
+            expect(resultValue.count).toEqual("5");
+        });
+        it("returns 1 for primitive non-string values", () => {
+            expect(ResultValue.from(42, "Test").count).toEqual("1");
+            expect(ResultValue.from(true, "Test").count).toEqual("1");
+        });
+        it("returns 0 for null and undefined", () => {
+            expect(ResultValue.from(null, "Test").count).toEqual("0");
+            expect(ResultValue.from(undefined, "Test").count).toEqual("0");
+        });
+    });
     describe("chaining shortcuts", () => {
         it("should be possible to chain upper, lower and trim", () => {
             // Arrange

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -202,6 +202,23 @@ export class ResultValue<T = unknown> {
     }
 
     /**
+     * Returns the number of items represented by the value as a string.
+     * Useful for templates that need to render counts, e.g. how many items
+     * were selected in a multiselect: `{{ tags | count }}`.
+     * - Arrays return their length.
+     * - Strings return their character length.
+     * - `null` and `undefined` return `0`.
+     * - Any other value returns `1` (a single item).
+     */
+    get count(): string {
+        const value = this.value;
+        if (value == null) return "0";
+        if (Array.isArray(value)) return String(value.length);
+        if (typeof value === "string") return String(value.length);
+        return "1";
+    }
+
+    /**
      * renders the value as a markdown link.
      * If the value is a string, it will be rendered as a markdown link.
      * If the value is a FileProxy (right now just used for images), it will be rendered as an embedded link.

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -211,6 +211,38 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("Hello, John! You are 18 years old."));
     });
 
+    it("Should execute a template with count transformation on an array", () => {
+        const template = "You picked {{ items | count }} items.";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { items: ["a", "b", "c"] }),
+            ),
+        );
+        expect(result).toEqual(E.of("You picked 3 items."));
+    });
+
+    it("Count on a string returns its character length", () => {
+        const template = "{{ name | count }}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "hello" })),
+        );
+        expect(result).toEqual(E.of("5"));
+    });
+
+    it("Count on a non-array, non-string value returns 1", () => {
+        const template = "{{ age | count }}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { age: 42 })),
+        );
+        expect(result).toEqual(E.of("1"));
+    });
+
     it("should parse a frontmatter command", () => {
         const template = "{#frontmatter#}";
         const result = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -252,6 +252,10 @@ function executeTransformation(
                 return JSON.stringify(value);
             case "trim":
                 return String(value).trim();
+            case "count":
+                if (Array.isArray(value)) return String(value.length);
+                if (typeof value === "string") return String(value.length);
+                return "1";
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -22,6 +22,7 @@ export const transformations = union([
     literal("lower"),
     literal("trim"),
     literal("stringify"),
+    literal("count"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds a new `count` transformation to the template system, alongside the existing `upper`, `lower`, `trim`, and `stringify`. It renders the number of items represented by a value — particularly useful for rendering snippets like "You picked X items." from a multiselect, where today the template author would have to drop into Templater post-processing.

The same shortcut is also exposed on `ResultValue` as a getter, so it can be used via the proxy API (`result.tags.count`) and stays consistent with how `upper`, `lower`, `trimmed`, `bullets`, and `link` are exposed both on the template and the API side.

### Before vs. after

Before, given a multiselect `tags` with `["work", "urgent"]`:

```plaintext
You picked {{ tags }} tags.
```

…rendered:

```plaintext
You picked work, urgent tags.
```

Now, with the new transformation:

```plaintext
You picked {{ tags | count }} tags.
```

…renders:

```plaintext
You picked 2 tags.
```

### Semantics

- Arrays return their length.
- Strings return their character length.
- Any other value returns `1` (a single item).
- On the `ResultValue` getter, `null` / `undefined` return `0`.

## Changes

- **`src/core/template/templateSchema.ts`** — adds `literal("count")` to the `transformations` valibot union so the parser accepts `| count`.
- **`src/core/template/templateParser.ts`** — handles the `count` branch in `executeTransformation`.
- **`src/core/ResultValue.ts`** — adds a `count` getter that mirrors the template-side semantics (plus `0` for nullish values).
- **`src/core/template/templateParser.test.ts`** — covers arrays, strings, and primitive values.
- **`src/core/ResultValue.test.ts`** — covers arrays (including empty), strings, primitives, `null`, and `undefined`.
- **`docs/templates.md`** and **`docs/ResultValue.md`** — document the new transformation/getter.

## Test plan

- [x] `npm run test` — all 167 tests pass.
- [x] `npm run build` — lint + svelte-check + bundle succeed (only pre-existing svelte warnings).
- [ ] Manual: open a form with a multiselect, submit, and verify `{{ field | count }}` renders the selection size in the resulting note.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxXZZXxnc1TKvqiVtLKUx6)_