### PR TITLE
feat: auto-focus first text-like input when form modal opens

### DIFF
--- a/src/FormModal.ts
+++ b/src/FormModal.ts
@@ -6,6 +6,7 @@ import FormResult, { type ModalFormData } from "./core/FormResult";
 import { formDataFromFormDefaults } from "./core/formDataFromFormDefaults";
 import type { FormDefinition, FormOptions } from "./core/formDefinition";
 import { FormEngine, makeFormEngine } from "./store/formEngine";
+import { focusFirstInput } from "./utils/focusFirstInput";
 import { log_notice } from "./utils/Log";
 
 export type SubmitFn = (formResult: FormResult) => void;
@@ -20,7 +21,8 @@ export class FormModal extends Modal {
     subscriptions: (() => void)[] = [];
     formEngine: FormEngine;
     private hasBeenHandled = false;
-    
+    private autoFocus: boolean;
+
     constructor(
         app: App,
         private modalDefinition: FormDefinition,
@@ -28,6 +30,7 @@ export class FormModal extends Modal {
         options?: FormOptions,
     ) {
         super(app);
+        this.autoFocus = options?.autoFocus ?? true;
         this.initialFormValues = formDataFromFormDefaults(
             modalDefinition.fields,
             options?.values ?? {},
@@ -101,6 +104,12 @@ export class FormModal extends Modal {
 
         contentEl.addEventListener("keydown", submitEnterCallback);
         contentEl.addEventListener("keydown", cancelEscapeCallback);
+
+        if (this.autoFocus) {
+            // Wait one frame so async field components (e.g. multiselect, note,
+            // dataview) have a chance to mount before we look for the first input.
+            requestAnimationFrame(() => focusFirstInput(contentEl));
+        }
     }
 
     onClose() {

--- a/src/core/formDefinition.ts
+++ b/src/core/formDefinition.ts
@@ -82,6 +82,14 @@ export type FormWithTemplate = Simplify<
 
 export type FormOptions = {
     values?: Record<string, unknown>;
+    /**
+     * When true (the default), the first text-like input is focused as soon as
+     * the modal opens. Set to false to suppress auto-focus — useful when the
+     * form starts with a long markdown_block / document_block intro the user
+     * should read first, or when opening the form on mobile where focusing an
+     * input pops up the keyboard immediately.
+     */
+    autoFocus?: boolean;
 };
 
 type KeyOfUnion<T> = T extends unknown ? keyof T : never;

--- a/src/utils/focusFirstInput.test.ts
+++ b/src/utils/focusFirstInput.test.ts
@@ -1,0 +1,48 @@
+import { INPUT_FOCUS_SELECTOR, focusFirstInput } from "./focusFirstInput";
+
+describe("focusFirstInput", () => {
+    it("targets the common text-like input types, textarea and select", () => {
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="text"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="number"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="email"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="tel"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="date"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="time"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="datetime-local"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain("textarea:not([disabled])");
+        expect(INPUT_FOCUS_SELECTOR).toContain("select:not([disabled])");
+    });
+
+    it("does not target controls that should not be auto-focused", () => {
+        // Buttons, toggles, sliders, files etc. should not be picked.
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="button"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="submit"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="checkbox"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="radio"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="file"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="range"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="color"]');
+        expect(INPUT_FOCUS_SELECTOR).not.toContain('input[type="hidden"]');
+    });
+
+    it("focuses the first matching element when querySelector finds one", () => {
+        const focusSpy = jest.fn();
+        const element = { focus: focusSpy } as unknown as HTMLElement;
+        const root = {
+            querySelector: jest.fn().mockReturnValue(element),
+        } as unknown as ParentNode;
+
+        focusFirstInput(root);
+
+        expect(root.querySelector).toHaveBeenCalledWith(INPUT_FOCUS_SELECTOR);
+        expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when no input is found", () => {
+        const root = {
+            querySelector: jest.fn().mockReturnValue(null),
+        } as unknown as ParentNode;
+
+        expect(() => focusFirstInput(root)).not.toThrow();
+    });
+});

--- a/src/utils/focusFirstInput.test.ts
+++ b/src/utils/focusFirstInput.test.ts
@@ -9,6 +9,9 @@ describe("focusFirstInput", () => {
         expect(INPUT_FOCUS_SELECTOR).toContain('input[type="date"]:not([disabled])');
         expect(INPUT_FOCUS_SELECTOR).toContain('input[type="time"]:not([disabled])');
         expect(INPUT_FOCUS_SELECTOR).toContain('input[type="datetime-local"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="search"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="url"]:not([disabled])');
+        expect(INPUT_FOCUS_SELECTOR).toContain('input[type="password"]:not([disabled])');
         expect(INPUT_FOCUS_SELECTOR).toContain("textarea:not([disabled])");
         expect(INPUT_FOCUS_SELECTOR).toContain("select:not([disabled])");
     });

--- a/src/utils/focusFirstInput.ts
+++ b/src/utils/focusFirstInput.ts
@@ -1,0 +1,33 @@
+/**
+ * Input types we will auto-focus when a form modal opens.
+ * We exclude non-text controls (checkbox, radio, file, range, color…) and
+ * buttons because focusing them on open is rarely what the user wants —
+ * they expect to start typing in the first text-like field.
+ */
+const FOCUSABLE_INPUT_TYPES = [
+    "text",
+    "number",
+    "email",
+    "tel",
+    "search",
+    "date",
+    "time",
+    "datetime-local",
+    "url",
+    "password",
+] as const;
+
+export const INPUT_FOCUS_SELECTOR = [
+    ...FOCUSABLE_INPUT_TYPES.map((t) => `input[type="${t}"]:not([disabled])`),
+    "textarea:not([disabled])",
+    "select:not([disabled])",
+].join(", ");
+
+/**
+ * Focus the first focusable text-like input inside `root`, if any.
+ * Safe to call on a root that contains no matching input.
+ */
+export function focusFirstInput(root: ParentNode): void {
+    const first = root.querySelector<HTMLElement>(INPUT_FOCUS_SELECTOR);
+    first?.focus();
+}


### PR DESCRIPTION
## Summary

The form modal used to open with no field focused — every user had to either click into the first input or press Tab before they could start typing. This PR auto-focuses the first text-like input as soon as the modal mounts, matching the conventional behavior of most web/desktop form dialogs.

### Before vs. after

Before, opening a form via `modalForms.openForm("note")` from Templater/QuickAdd showed the modal with no field focused — the user had to click or Tab in before typing.

Now, the first focusable text-like input is auto-focused, so the user can immediately start typing into it.

### Which inputs get focused

Only the inputs where auto-focus makes sense — i.e. text-like fields the user is about to type into. Specifically:

- `text`, `number`, `email`, `tel`, `search`, `date`, `time`, `datetime-local`, `url`, `password` inputs
- `textarea` and `select`

Skipped: `toggle`, `slider` (range), `file`, `checkbox`, `radio`, `color`, `hidden`, buttons, anything `[disabled]`. Auto-focusing a toggle or a range slider is rarely what the user wants, and auto-focusing a file/color picker just feels jumpy.

If a form starts with a `markdown_block` / `document_block` and the first actual input comes later in the form, that one gets focused (the selector doesn't care what comes before).

### Opt-out

A new `FormOptions.autoFocus` flag lets callers turn it off per `openForm` call. Useful when:

- The form starts with a long markdown intro the user should read first.
- On mobile, where focusing an input immediately pops up the on-screen keyboard.

```typescript
await modalForms.openForm("welcome", { autoFocus: false });
```

The default is `true`, so existing callers gain the new behavior with no changes.

### Why `requestAnimationFrame`

A handful of field components (`multiselect`, `note`, `dataview`) wrap their UI in a `Promise.resolve(model)` and mount asynchronously. Calling `focus()` immediately after `new FormModalComponent(...)` would race them and sometimes pick a later field. Waiting one frame is enough for them to commit their DOM, and is still fast enough to feel instant to the user.

## Changes

- **`src/utils/focusFirstInput.ts`** (new) — small helper exporting `INPUT_FOCUS_SELECTOR` (the CSS selector built from the allowed input types) and `focusFirstInput(root)` which queries the root and focuses the first match. Pure and side-effect-free apart from the `.focus()` call.
- **`src/utils/focusFirstInput.test.ts`** (new) — 4 tests: the selector targets the right input types, it does NOT target the controls that shouldn't auto-focus (buttons/toggles/sliders/files/etc.), `focusFirstInput` calls `.focus()` on the queried element, and it's a no-op when nothing matches.
- **`src/core/formDefinition.ts`** — adds `autoFocus?: boolean` to `FormOptions` with a docstring explaining when callers might want to disable it.
- **`src/FormModal.ts`** — reads `options?.autoFocus ?? true` in the constructor and, in `onOpen`, schedules `focusFirstInput(contentEl)` inside a `requestAnimationFrame` after the Svelte component is created and the Cancel/Submit buttons are appended.

No schema changes; no migration needed. Existing forms and existing callers behave identically except for the new auto-focus on open.

## Test plan

- [x] `npm run test` — 163 tests pass (was 159, +4 new), 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) — `svelte-check found 0 errors`, only the 5 pre-existing warnings (Toggle a11y, unused `.clear-button` CSS, unused Toggle import)
- [ ] Preview URL: open a form that starts with a `text` field — confirm the cursor is in the input on open and you can type immediately without clicking
- [ ] Preview URL: open a form that starts with a `toggle` followed by a `text` field — confirm the `text` field gets focus (not the toggle)
- [ ] Preview URL: open a form that starts with a `markdown_block` followed by a `number` field — confirm the `number` field gets focus
- [ ] Preview URL: call `modalForms.openForm(name, { autoFocus: false })` and confirm no field is focused on open
- [ ] Preview URL: confirm Tab still moves through fields normally and Cmd/Ctrl+Enter still submits

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bh9anoyuRYa23JUL3oqi3Z)_