### PR TITLE
feat: add `capitalize` template transformation

### DIFF
--- a/docs/ResultValue.md
+++ b/docs/ResultValue.md
@@ -88,7 +88,7 @@ The above code will print the list field as a bullet list, but all the values wi
 The map method takes a function that takes the value and returns a new value.
 It can be used when none of the provided printing are enough for your use case, or when one of them is almost what you need but you need to transform the value a bit more.
 
-### `trimmed`,`lower`,`upper` shortcuts
+### `trimmed`,`lower`,`upper`,`capitalized` shortcuts
 
 The ResultValue class provides some shortcuts to common transformations of the value.
 They are:
@@ -96,6 +96,7 @@ They are:
 - `trimmed`: Trims the value, removing any leading or trailing whitespace.
 - `lower`: Converts the value to lowercase.
 - `upper`: Converts the value to uppercase.
+- `capitalized`: Uppercases the first character and leaves the rest untouched. Chain after `lower` (e.g. `result.getValue('name').lower.capitalized`) if you also want the remaining characters lowercased.
 
 All of these shortcuts return a new ResultValue object, so you can chain them with other methods.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -86,6 +86,15 @@ The following transformations can be applied to variables:
      {{ name | stringify }}
      ```
 
+5. **`capitalize`**: Uppercases the first character of the variable's value and leaves the rest untouched.
+   - Usage:
+
+     ```plaintext
+     {{ name | capitalize }}
+     ```
+
+   - Input `john doe` produces `John doe`; input `jOHN doe` produces `JOHN doe`. To force a clean Title-style start (first letter uppercased, rest lowercased), use the `capitalized` getter on `ResultValue` together with `lower` — e.g. `result.getValue('name').lower.capitalized` — since templates accept only one transformation per variable.
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -284,6 +284,32 @@ describe("ResultValue", () => {
             expect(trimmed.toString()).toEqual("test");
         });
     })
+    describe("capitalized", () => {
+        it("should uppercase the first character of a string", () => {
+            const resultValue = ResultValue.from("hello world", "Test");
+            expect(resultValue.capitalized.toString()).toEqual("Hello world");
+        });
+        it("should leave the rest of the string untouched", () => {
+            const resultValue = ResultValue.from("jOHN doe", "Test");
+            expect(resultValue.capitalized.toString()).toEqual("JOHN doe");
+        });
+        it("should capitalize each string in an array individually", () => {
+            const resultValue = ResultValue.from(["foo", "bar"], "Test");
+            expect(resultValue.capitalized.toString()).toEqual("Foo, Bar");
+        });
+        it("should leave non-string values unchanged in mixed arrays", () => {
+            const resultValue = ResultValue.from(["foo", 42], "Test");
+            expect(resultValue.capitalized.bullets).toEqual("- Foo\n- 42");
+        });
+        it("should handle an empty string without crashing", () => {
+            const resultValue = ResultValue.from("", "Test");
+            expect(resultValue.capitalized.toString()).toEqual("");
+        });
+        it("should be chainable", () => {
+            const resultValue = ResultValue.from(" hello", "Test");
+            expect(resultValue.trimmed.capitalized.toString()).toEqual("Hello");
+        });
+    });
     describe("chaining shortcuts", () => {
         it("should be possible to chain upper, lower and trim", () => {
             // Arrange

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -207,7 +207,8 @@ export class ResultValue<T = unknown> {
      * values are returned unchanged. Empty strings stay empty.
      */
     get capitalized(): ResultValue<unknown> {
-        const cap = (s: string) => (s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1));
+        const cap = (s: string) =>
+            s.length === 0 ? s : s.charAt(0).toLocaleUpperCase() + s.slice(1);
         if (this.value instanceof FileProxy) {
             return new ResultValue(cap(this.value.name), this.name, this.notify);
         }

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -202,6 +202,19 @@ export class ResultValue<T = unknown> {
     }
 
     /**
+     * getter that returns the value with the first character uppercased.
+     * Strings nested in arrays/objects are capitalized individually; non-string
+     * values are returned unchanged. Empty strings stay empty.
+     */
+    get capitalized(): ResultValue<unknown> {
+        const cap = (s: string) => (s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1));
+        if (this.value instanceof FileProxy) {
+            return new ResultValue(cap(this.value.name), this.name, this.notify);
+        }
+        return this.map((v) => deepMap(v, (it) => (typeof it === "string" ? cap(it) : it)));
+    }
+
+    /**
      * renders the value as a markdown link.
      * If the value is a string, it will be rendered as a markdown link.
      * If the value is a FileProxy (right now just used for images), it will be rendered as an embedded link.

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -211,6 +211,41 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("Hello, John! You are 18 years old."));
     });
 
+    it("Should execute a template with capitalize transformation", () => {
+        const template = "Hello, {{name|capitalize}}!";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { name: "john", age: 18 }),
+            ),
+            E.map(tap("executed")),
+        );
+        expect(result).toEqual(E.of("Hello, John!"));
+    });
+
+    it("capitalize should leave the rest of the string untouched", () => {
+        const template = "{{name|capitalize}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { name: "jOHN doe" }),
+            ),
+        );
+        expect(result).toEqual(E.of("JOHN doe"));
+    });
+
+    it("capitalize should handle an empty string without crashing", () => {
+        const template = "[{{name|capitalize}}]";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "" })),
+        );
+        expect(result).toEqual(E.of("[]"));
+    });
+
     it("should parse a frontmatter command", () => {
         const template = "{#frontmatter#}";
         const result = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -252,6 +252,11 @@ function executeTransformation(
                 return JSON.stringify(value);
             case "trim":
                 return String(value).trim();
+            case "capitalize": {
+                const str = String(value);
+                const first = str.charAt(0).toUpperCase();
+                return first + str.slice(1);
+            }
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -22,6 +22,7 @@ export const transformations = union([
     literal("lower"),
     literal("trim"),
     literal("stringify"),
+    literal("capitalize"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds a `capitalize` transformation to the template system, alongside the existing `upper`, `lower`, `trim`, and `stringify`. It uppercases the first character of the variable's value and leaves the rest untouched — the common "sentence case" need that previously required Templater post-processing.

The same shortcut is also exposed on `ResultValue` as a `capitalized` getter, matching how `upper`/`lower`/`trimmed` are exposed on both the template and the API side.

### Before vs. after

Before, given a `name` field with value `john`:

```plaintext
Hello, {{ name }}!
```

…rendered:

```plaintext
Hello, john!
```

Now, with the new transformation:

```plaintext
Hello, {{ name | capitalize }}!
```

…renders:

```plaintext
Hello, John!
```

### Semantics

- Uppercases the first character only; the rest of the string is preserved as-is. So `jOHN doe` → `JOHN doe`. To get strict Title-style "John doe", chain `lower` + `capitalized` via the `ResultValue` getter (`result.getValue('name').lower.capitalized`) since templates accept only one transformation per variable.
- Empty strings stay empty (no crash).
- On the `ResultValue` getter, arrays and objects are recursed into (consistent with `upper`/`lower`/`trimmed`), so a multiselect of names renders as `Foo, Bar` instead of `Foo, bar`. Non-string values inside arrays are left unchanged.

## Changes

- **`src/core/template/templateSchema.ts`** — adds `literal("capitalize")` to the `transformations` valibot union so the parser accepts `| capitalize`.
- **`src/core/template/templateParser.ts`** — handles the new `capitalize` case in `executeTransformation`, using `charAt(0)` so empty strings don't crash under `noUncheckedIndexedAccess`.
- **`src/core/ResultValue.ts`** — adds a `capitalized` getter that mirrors the template-side semantics and recurses through arrays/objects via the existing `deepMap` helper (same pattern used by `upper`/`lower`/`trimmed`).
- **`src/core/template/templateParser.test.ts`** — covers the basic case, the "rest of the string is untouched" guarantee, and the empty-string edge case.
- **`src/core/ResultValue.test.ts`** — covers single strings, the rest-untouched guarantee, arrays, mixed-type arrays, empty strings, and chainability with `trimmed`.
- **`docs/templates.md`** and **`docs/ResultValue.md`** — document the new transformation/getter alongside the existing ones, including the `lower.capitalized` recipe for strict Title-style output.

## Test plan

- [x] `npm run test` — 168 tests pass (was 159, +9 new), 2 pre-existing skipped
- [x] `npm run build` (lint + svelte-check + esbuild production bundle) — `svelte-check found 0 errors`, only the 5 pre-existing warnings (Toggle a11y x3, unused `.clear-button`/`.clear-button:hover` CSS)
- [ ] Preview URL: open a form with a `text` field, set the template to `Hello, {{ name | capitalize }}!`, type `john` and confirm the rendered output is `Hello, John!`
- [ ] Preview URL: confirm `{{ name | capitalize }}` with `jOHN doe` renders as `JOHN doe` (rest of the string untouched)
- [ ] Preview URL: confirm `<% result.attendees.capitalized %>` with a multiselect of `["foo", "bar"]` renders as `Foo, Bar`
- [ ] Preview URL: confirm existing transformations (`upper`, `lower`, `trim`, `stringify`) still work unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01MutxPLZtSw3vpvmonvS13o)_