### PR TITLE
fix: return empty string instead of invalid YAML when frontmatter output is empty

### DIFF
--- a/src/core/FormResult.test.ts
+++ b/src/core/FormResult.test.ts
@@ -149,6 +149,16 @@ age: 30`;
                     .trim(),
             ).toEqual(expectedOutput);
         });
+
+        it("should return an empty string when the picked keys are not present in the data", () => {
+            const result = FormResult.make(formData, "ok");
+            expect(result.asFrontmatterString({ pick: ["doesNotExist"] })).toEqual("");
+        });
+
+        it("should return an empty string when the form data is empty", () => {
+            const result = FormResult.make({}, "ok");
+            expect(result.asFrontmatterString()).toEqual("");
+        });
     });
     describe("get a single value", () => {
         it("should return the value of the specified key", () => {

--- a/src/core/FormResult.ts
+++ b/src/core/FormResult.ts
@@ -46,6 +46,11 @@ export default class FormResult {
      */
     asFrontmatterString(options?: unknown) {
         const data = objectSelect(this.data, options);
+        // stringifyYaml renders an empty object as the literal "{}",
+        // which is invalid when embedded inside a frontmatter block
+        if (Object.keys(data).length === 0) {
+            return "";
+        }
         return stringifyYaml(data);
     }
 

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -293,4 +293,13 @@ describe("parseTemplate", () => {
         );
         expect(result).toEqual(E.of(stringifyYaml({ name: "John" })));
     });
+    it("Should produce an empty string when a frontmatter command picks fields missing from the data", () => {
+        const template = "{# frontmatter pick: doesNotExist #}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
+        );
+        expect(result).toEqual(E.of(""));
+    });
 });

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -232,7 +232,9 @@ function asFrontmatterString(data: Record<string, unknown>) {
                 return pick.includes(key) ? O.some(value) : O.none;
             }),
             R.filterMapWithIndex((key, value) => (!omit.includes(key) ? O.some(value) : O.none)),
-            stringifyYaml,
+            // stringifyYaml renders an empty object as the literal "{}",
+            // which is invalid when embedded inside a frontmatter block
+            (selected) => (Object.keys(selected).length === 0 ? "" : stringifyYaml(selected)),
         );
 }
 


### PR DESCRIPTION
## Summary

Fixes #480.

When every field selected via `asFrontmatterString({ pick: [...] })` was left empty in the form, the selected data object was empty (empty fields are never included in the form result), and Obsidian's `stringifyYaml({})` produced the literal string `{}`. Embedded inside a frontmatter block, that is invalid YAML and made Obsidian throw:

```
YAMLParseError: Implicit map keys need to be followed by map values
```

## Changes

- `FormResult.asFrontmatterString` (and its aliases `asFrontmatter` / `asYaml`) now returns an empty string when the pick/omit selection yields no data.
- The `{# frontmatter #}` template command in `templateParser.ts` had the same flaw and gets the same guard.
- Added regression tests for both code paths.

## Testing

- `npm run test` — 171 passed, 2 skipped
- `npm run build` — lint, svelte-check, and production bundle all pass

https://claude.ai/code/session_01V2eYNDZPPCk4FnDkFFnCdp

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2eYNDZPPCk4FnDkFFnCdp)_