### PR TITLE
feat: add `title` template transformation

### DIFF
--- a/docs/ResultValue.md
+++ b/docs/ResultValue.md
@@ -88,7 +88,7 @@ The above code will print the list field as a bullet list, but all the values wi
 The map method takes a function that takes the value and returns a new value.
 It can be used when none of the provided printing are enough for your use case, or when one of them is almost what you need but you need to transform the value a bit more.
 
-### `trimmed`,`lower`,`upper`,`capitalized`,`slug` shortcuts
+### `trimmed`,`lower`,`upper`,`capitalized`,`slug`,`title` shortcuts
 
 The ResultValue class provides some shortcuts to common transformations of the value.
 They are:
@@ -98,6 +98,7 @@ They are:
 - `upper`: Converts the value to uppercase.
 - `capitalized`: Uppercases the first character and leaves the rest untouched. Chain after `lower` (e.g. `result.getValue('name').lower.capitalized`) if you also want the remaining characters lowercased.
 - `slug`: Converts the value to a URL/filename-friendly slug. Lowercases the value, turns whitespace and underscores into `-`, strips punctuation, collapses runs of dashes, and trims edge dashes. Unicode letters/numbers are preserved so `Café Noël` becomes `café-noël`. Handy for turning a form's title into a filename: `result.getValue('title').slug`.
+- `title`: Uppercases the first character of every word and leaves the rest of each word untouched. Chain after `lower` (e.g. `result.getValue('name').lower.title`) if you also want the remaining characters lowercased.
 
 All of these shortcuts return a new ResultValue object, so you can chain them with other methods.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -107,6 +107,15 @@ The following transformations can be applied to variables:
 
    - Input `Hello, World!` produces `hello-world`; input `  My Note (2024)  ` produces `my-note-2024`.
 
+7. **`title`**: Uppercases the first character of every word and leaves the rest of each word untouched.
+   - Usage:
+
+     ```plaintext
+     {{ name | title }}
+     ```
+
+   - Input `hello world` produces `Hello World`; input `the iPhone of jOHN` produces `The IPhone Of JOHN` (acronyms and inner casing are preserved). To force every word to a clean Title-style start, chain `lower` and `title` via `ResultValue` — e.g. `result.getValue('name').lower.title`.
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-modal-form",
-    "version": "1.63.1",
+    "version": "1.67.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-modal-form",
-            "version": "1.63.1",
+            "version": "1.67.0",
             "license": "MIT",
             "dependencies": {
                 "fp-ts": "^2.16.1",

--- a/src/core/FormResult.test.ts
+++ b/src/core/FormResult.test.ts
@@ -91,6 +91,11 @@ isEmployed:: true`;
             expect(result.asString("{{ word | capitalize }}")).toEqual("Hello");
         });
 
+        it("should apply the title transformation", () => {
+            const result = FormResult.make({ phrase: "hello world" }, "ok");
+            expect(result.asString("{{ phrase | title }}")).toEqual("Hello World");
+        });
+
         it("should apply the stringify transformation", () => {
             const result = FormResult.make(formData, "ok");
             expect(result.asString("{{ hobbies | stringify }}")).toEqual(

--- a/src/core/FormResult.ts
+++ b/src/core/FormResult.ts
@@ -75,7 +75,8 @@ export default class FormResult {
      * Variables use the `{{ key }}` syntax. Optional whitespace is allowed
      * around the key, and a transformation can be applied with `|`, e.g.
      * `{{ key | upper }}`. Supported transformations match the ones used by
-     * form templates: `upper`, `lower`, `trim`, `stringify`, `capitalize`.
+     * form templates: `upper`, `lower`, `trim`, `stringify`, `capitalize`,
+     * `slug`, `title`.
      * Unknown keys are left untouched (the literal `{{ key }}` stays in the
      * output) so users can spot typos easily.
      */

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -344,6 +344,32 @@ describe("ResultValue", () => {
             expect(resultValue.trimmed.slug.toString()).toEqual("hello-world");
         });
     });
+    describe("title", () => {
+        it("should uppercase the first character of every word", () => {
+            const resultValue = ResultValue.from("hello world", "Test");
+            expect(resultValue.title.toString()).toEqual("Hello World");
+        });
+        it("should leave the rest of every word's characters untouched", () => {
+            const resultValue = ResultValue.from("the iPhone of jOHN", "Test");
+            expect(resultValue.title.toString()).toEqual("The IPhone Of JOHN");
+        });
+        it("should title-case each string in an array individually", () => {
+            const resultValue = ResultValue.from(["hello world", "foo bar"], "Test");
+            expect(resultValue.title.toString()).toEqual("Hello World, Foo Bar");
+        });
+        it("should leave non-string values unchanged in mixed arrays", () => {
+            const resultValue = ResultValue.from(["foo bar", 42], "Test");
+            expect(resultValue.title.bullets).toEqual("- Foo Bar\n- 42");
+        });
+        it("should handle an empty string without crashing", () => {
+            const resultValue = ResultValue.from("", "Test");
+            expect(resultValue.title.toString()).toEqual("");
+        });
+        it("should be chainable", () => {
+            const resultValue = ResultValue.from(" hello world", "Test");
+            expect(resultValue.trimmed.title.toString()).toEqual("Hello World");
+        });
+    });
     describe("chaining shortcuts", () => {
         it("should be possible to chain upper, lower and trim", () => {
             // Arrange

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -1,7 +1,7 @@
 import { E, O, ensureError, pipe } from "@std";
 import { notifyError } from "src/utils/Log";
 import { FileProxy } from "./files/FileProxy";
-import { toSlug } from "./template/templateParser";
+import { toSlug, toTitleCase } from "./template/templateParser";
 
 function _toBulletList(value: Record<string, unknown> | unknown[]) {
     if (Array.isArray(value)) {
@@ -228,6 +228,22 @@ export class ResultValue<T = unknown> {
             return new ResultValue(toSlug(this.value.name), this.name, this.notify);
         }
         return this.map((v) => deepMap(v, (it) => (typeof it === "string" ? toSlug(it) : it)));
+    }
+
+    /**
+     * getter that returns the value as Title Case: every word's first
+     * character is uppercased, the rest of the characters are left
+     * untouched (so acronyms like "iOS" stay as written). Strings nested
+     * in arrays/objects are title-cased individually; non-string values
+     * are returned unchanged.
+     */
+    get title(): ResultValue<unknown> {
+        if (this.value instanceof FileProxy) {
+            return new ResultValue(toTitleCase(this.value.name), this.name, this.notify);
+        }
+        return this.map((v) =>
+            deepMap(v, (it) => (typeof it === "string" ? toTitleCase(it) : it)),
+        );
     }
 
     /**

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -292,6 +292,40 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("[]"));
     });
 
+    it("Should execute a template with title transformation", () => {
+        const template = "{{name|title}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { name: "hello world" }),
+            ),
+        );
+        expect(result).toEqual(E.of("Hello World"));
+    });
+
+    it("title should preserve casing of non-leading characters", () => {
+        const template = "{{name|title}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { name: "the iPhone of jOHN" }),
+            ),
+        );
+        expect(result).toEqual(E.of("The IPhone Of JOHN"));
+    });
+
+    it("title should handle an empty string without crashing", () => {
+        const template = "[{{name|title}}]";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "" })),
+        );
+        expect(result).toEqual(E.of("[]"));
+    });
+
     it("should parse a frontmatter command", () => {
         const template = "{#frontmatter#}";
         const result = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -251,6 +251,13 @@ export function toSlug(value: string): string {
         .replace(/^-+|-+$/g, "");
 }
 
+// Uppercases the first character of every word, leaving the rest of the
+// characters untouched (so "iPhone" stays "iPhone"). Word boundaries are
+// runs of whitespace, matching how most "Title Case" helpers behave.
+export function toTitleCase(value: string): string {
+    return value.replace(/(^|\s)(\S)/g, (_, sep: string, ch: string) => sep + ch.toLocaleUpperCase());
+}
+
 export function executeTransformation(
     transformation: Transformations | undefined,
 ): (value: Val) => string {
@@ -274,6 +281,8 @@ export function executeTransformation(
             }
             case "slug":
                 return toSlug(String(value));
+            case "title":
+                return toTitleCase(String(value));
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -24,6 +24,7 @@ export const transformations = union([
     literal("stringify"),
     literal("capitalize"),
     literal("slug"),
+    literal("title"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds a new `title` transformation to the template system, alongside the existing `upper`, `lower`, `trim`, `stringify`, and `capitalize`. It uppercases the first character of every word and leaves the rest of each word untouched, so acronyms and inner casing (`iPhone`, `iOS`, etc.) survive the transformation.

This is the natural complement to `capitalize`, which only touches the first character of the whole string:

- `{{ name | capitalize }}` on `"hello world"` → `"Hello world"`
- `{{ name | title }}`      on `"hello world"` → `"Hello World"`

### How it's exposed

Following the pattern established by `capitalize`, the transformation is wired into the three usual entry-points:

1. **Form templates** — `{{ name | title }}` in the form's template body.
2. **`FormResult.asString`** — `result.asString("Hello {{ name | title }}!")` from the API.
3. **`ResultValue.title` getter** — `result.getValue('name').title`, which handles arrays/objects by title-casing nested strings individually, and `FileProxy` values by title-casing the filename. Chainable with the other shortcuts, e.g. `result.getValue('name').lower.title` if you also want every other character lowercased.

### Examples

```plaintext
{{ phrase | title }}
```

| Input                  | Output                  |
| ---------------------- | ----------------------- |
| `hello world`          | `Hello World`           |
| `the iPhone of jOHN`   | `The IPhone Of JOHN`    |
| `  spaced   out  `     | `  Spaced   Out  `      |
| `""` (empty)           | `""`                    |

### What's covered

- Schema (`templateSchema.ts`) — `title` added to the `transformations` union.
- Executor (`templateParser.ts`) — new exported `toTitleCase` helper plus the `case "title"` branch in `executeTransformation`.
- `ResultValue.title` getter, including `FileProxy` handling and deep-mapping over arrays/objects.
- `FormResult.asString` doc updated to list `title` among the supported transformations.
- Docs (`docs/templates.md`, `docs/ResultValue.md`) updated.
- Tests added in `templateParser.test.ts`, `ResultValue.test.ts`, and `FormResult.test.ts` — empty-string handling, array values with mixed types, casing preservation on inner characters, and `.trimmed.title` chaining.

## Test plan

- [x] `npm run test` — all 192 tests pass (190 passing, 2 pre-existing skipped).
- [x] `npm run build` — passes lint + svelte-check + production bundle. Only pre-existing warnings (unchanged from `master`).
- [ ] Confirm the preview vault still loads the plugin with the new transformation working in a template.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KeQMkTx83FdA5MK3ceq6S8)_