### PR TITLE
Resolve form definition circular dependencies

### DIFF
--- a/src/core/fieldDefinitionSchema.ts
+++ b/src/core/fieldDefinitionSchema.ts
@@ -1,0 +1,24 @@
+import { array, boolean, merge, object, optional, passthrough, string, type Output } from "valibot";
+import { ConditionSchema } from "./input/dependentFields";
+import { InputTypeSchema, nonEmptyString } from "./input/InputDefinitionSchema";
+
+export const FieldDefinitionSchema = object({
+    name: nonEmptyString("field name"),
+    label: optional(string()),
+    description: string(),
+    isRequired: optional(boolean()),
+    condition: optional(ConditionSchema),
+    input: InputTypeSchema,
+});
+
+/**
+ * Only for error reporting purposes
+ */
+export const FieldMinimalSchema = passthrough(
+    merge([FieldDefinitionSchema, object({ input: passthrough(object({ type: string() })) })]),
+);
+
+export const FieldListSchema = array(FieldDefinitionSchema);
+
+export type FieldDefinition = Output<typeof FieldDefinitionSchema>;
+export type FieldMinimal = Output<typeof FieldMinimalSchema>;

--- a/src/core/findInputDefinitionSchema.ts
+++ b/src/core/findInputDefinitionSchema.ts
@@ -1,8 +1,9 @@
 import { A, NonEmptyArray, ParsingFn, parse, pipe } from "@std";
 import * as E from "fp-ts/Either";
 import { BaseSchema, ValiError } from "valibot";
-import { AllFieldTypes } from "./formDefinition";
-import { FieldMinimal, FieldMinimalSchema } from "./formDefinitionSchema";
+import type { FieldMinimal } from "./fieldDefinitionSchema";
+import { FieldMinimalSchema } from "./fieldDefinitionSchema";
+import type { AllFieldTypes } from "./input/inputDefinitionTypes";
 import { InputTypeToParserMap } from "./input/InputDefinitionSchema";
 
 export function stringifyIssues(error: ValiError): NonEmptyArray<string> {

--- a/src/core/formDefinition.ts
+++ b/src/core/formDefinition.ts
@@ -1,14 +1,14 @@
 import { input } from "@core";
 import { A, O, pipe } from "@std";
 import { Simplify } from "type-fest";
-import { is, safeParse, type Output } from "valibot";
+import { is, safeParse } from "valibot";
 import {
-    FieldDefinitionSchema,
     FieldListSchema,
     FormDefinitionBasicSchema,
-    FormDefinitionLatestSchema,
     MigrationError,
+    type FormDefinition,
 } from "./formDefinitionSchema";
+import type { AllFieldTypes, AllSources } from "./input/inputDefinitionTypes";
 import {
     InputBasicSchema,
     InputDataviewSourceSchema,
@@ -27,6 +27,9 @@ import {
     multiselect,
     selectFromNotes,
 } from "./input/InputDefinitionSchema";
+
+export type { FieldDefinition, FormDefinition } from "./formDefinitionSchema";
+export type { AllFieldTypes, AllSources } from "./input/inputDefinitionTypes";
 
 export const InputTypeReadable: Record<AllFieldTypes, string> = {
     text: "Text",
@@ -69,13 +72,9 @@ export function isInputSelectFixed(input: unknown): input is inputSelectFixed {
     return is(InputSelectFixedSchema, input);
 }
 
-export type AllFieldTypes = inputType["type"];
-
-export type FieldDefinition = Output<typeof FieldDefinitionSchema>;
 /**
  * FormDefinition is an already valid form, ready to be used in the form modal.
  */
-export type FormDefinition = Output<typeof FormDefinitionLatestSchema>;
 export type FormWithTemplate = Simplify<
     FormDefinition & Required<Pick<FormDefinition, "template">>
 >;
@@ -83,15 +82,6 @@ export type FormWithTemplate = Simplify<
 export type FormOptions = {
     values?: Record<string, unknown>;
 };
-
-type KeyOfUnion<T> = T extends unknown ? keyof T : never;
-type PickUnion<T, K extends KeyOfUnion<T>> = T extends unknown
-    ? K & keyof T extends never
-        ? never
-        : Pick<T, K & keyof T>
-    : never;
-
-export type AllSources = PickUnion<inputType, "source">["source"];
 
 // When an input is in edit state, it is represented by this type.
 // It has all the possible values, and then you need to narrow it down

--- a/src/core/formDefinitionSchema.ts
+++ b/src/core/formDefinitionSchema.ts
@@ -1,4 +1,3 @@
-import { input } from "@core";
 import { parse, pipe } from "@std";
 import * as E from "fp-ts/Either";
 import {
@@ -10,15 +9,20 @@ import {
     merge,
     object,
     optional,
-    passthrough,
     string,
     unknown,
     type Output,
 } from "valibot";
 import { findFieldErrors, stringifyIssues } from "./findInputDefinitionSchema";
-import { FormDefinition } from "./formDefinition";
-import { InputTypeSchema, nonEmptyString } from "./input/InputDefinitionSchema";
+import { FieldListSchema } from "./fieldDefinitionSchema";
+import { nonEmptyString } from "./input/InputDefinitionSchema";
 import { ParsedTemplateSchema } from "./template/templateSchema";
+export {
+    FieldDefinitionSchema,
+    FieldListSchema,
+    FieldMinimalSchema,
+} from "./fieldDefinitionSchema";
+export type { FieldDefinition, FieldMinimal } from "./fieldDefinitionSchema";
 
 /**
  * Here are the core logic around the main domain of the plugin,
@@ -26,24 +30,6 @@ import { ParsedTemplateSchema } from "./template/templateSchema";
  * Here are the types, validators, rules etc.
  */
 
-export const FieldDefinitionSchema = object({
-    name: nonEmptyString("field name"),
-    label: optional(string()),
-    description: string(),
-    isRequired: optional(boolean()),
-    condition: optional(input.ConditionSchema),
-    input: InputTypeSchema,
-});
-/**
- * Only for error reporting purposes
- */
-export const FieldMinimalSchema = passthrough(
-    merge([FieldDefinitionSchema, object({ input: passthrough(object({ type: string() })) })]),
-);
-
-export type FieldMinimal = Output<typeof FieldMinimalSchema>;
-
-export const FieldListSchema = array(FieldDefinitionSchema);
 /**
  * This is the most basic representation of a form definition.
  * It is not useful for anything other than being the base for
@@ -66,7 +52,7 @@ const FormDefinitionV1Schema = merge([
         fields: FieldListSchema,
         template: optional(
             object({
-                createInsertCommand: optional(boolean(),() => false),
+                createInsertCommand: optional(boolean(), () => false),
                 createNoteCommand: optional(boolean(), () => false),
                 parsedTemplate: ParsedTemplateSchema,
             }),
@@ -76,6 +62,7 @@ const FormDefinitionV1Schema = merge([
 // This is the latest schema.
 // Make sure to update this when you add a new version.
 export const FormDefinitionLatestSchema = FormDefinitionV1Schema;
+export type FormDefinition = Output<typeof FormDefinitionLatestSchema>;
 type FormDefinitionV1 = Output<typeof FormDefinitionV1Schema>;
 type FormDefinitionBasic = Output<typeof FormDefinitionBasicSchema>;
 

--- a/src/core/input/InputDefinitionSchema.ts
+++ b/src/core/input/InputDefinitionSchema.ts
@@ -16,7 +16,7 @@ import {
     toTrimmed,
     union,
 } from "valibot";
-import { AllFieldTypes, AllSources } from "../formDefinition";
+import type { AllFieldTypes, AllSources } from "./inputDefinitionTypes";
 
 /**
  * Here are the definition for the input types.

--- a/src/core/input/dependentFields.ts
+++ b/src/core/input/dependentFields.ts
@@ -2,7 +2,7 @@ import { Str } from "@std";
 import * as Eq from "fp-ts/Eq";
 import { absurd } from "fp-ts/function";
 import * as v from "valibot";
-import { FieldDefinition } from "../formDefinition";
+import type { Input } from "./InputDefinitionSchema";
 const isSet = v.object({ dependencyName: v.string(), type: v.literal("isSet") });
 const booleanValue = v.object({
     dependencyName: v.string(),
@@ -30,7 +30,7 @@ export const ConditionEq = Eq.struct({
     value: Str.Eq,
 });
 
-export function availableConditionsForInput(input: FieldDefinition["input"]): ConditionType[] {
+export function availableConditionsForInput(input: Input): ConditionType[] {
     switch (input.type) {
         case "text":
         case "textarea":

--- a/src/core/input/inputDefinitionTypes.ts
+++ b/src/core/input/inputDefinitionTypes.ts
@@ -1,0 +1,23 @@
+export type AllFieldTypes =
+    | "text"
+    | "number"
+    | "date"
+    | "time"
+    | "datetime"
+    | "textarea"
+    | "toggle"
+    | "email"
+    | "tel"
+    | "select"
+    | "tag"
+    | "note"
+    | "folder"
+    | "slider"
+    | "dataview"
+    | "multiselect"
+    | "document_block"
+    | "markdown_block"
+    | "image"
+    | "file";
+
+export type AllSources = "notes" | "fixed" | "dataview";


### PR DESCRIPTION
## Summary
- extract field definition schemas into a dedicated module so error reporting can share them without importing the full form definition facade
- move input type/source unions into an import-free input type module
- update dependent-field typing to depend on input definitions directly instead of the form definition facade

Fixes #483.

## Verification
- eslint src
- 	sc --noEmit
- pnpm dlx madge --circular --extensions ts src/

## Notes
- svelte-check --tsconfig tsconfig.json still reports an existing src/main.ts class-property diagnostic plus existing Svelte warnings unrelated to this change.
- jest --detectOpenHandles could not start in this pnpm-based local verification because Jest requires 	s-node for jest.config.ts, but 	s-node is not listed in the installed dependencies.