### PR TITLE
Pass form values into dataview multiselect queries

### DIFF
--- a/src/suggesters/StringSuggest.ts
+++ b/src/suggesters/StringSuggest.ts
@@ -9,12 +9,14 @@ export class StringSuggest extends AbstractInputSuggest<string> {
         private onSelectCb: (value: string) => void,
         app: App,
         private allowUnknownValues = false,
+        private refreshContent: () => void | Promise<void> = () => {},
     ) {
         super(app, inputEl);
         this.content = content;
     }
 
-    getSuggestions(inputStr: string): string[] {
+    async getSuggestions(inputStr: string): Promise<string[]> {
+        await this.refreshContent();
         const lowerCaseInputStr = inputStr.toLocaleLowerCase();
         const candidates =
             this.allowUnknownValues && inputStr !== ""

--- a/src/views/components/Form/MultiSelectField.svelte
+++ b/src/views/components/Form/MultiSelectField.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
     import { input as I } from "@core";
+    import { pipe } from "@std";
+    import * as R from "fp-ts/Record";
     import { App } from "obsidian";
-    import { FieldValue } from "src/store/formEngine";
+    import { FieldValue, FormEngine } from "src/store/formEngine";
+    import { onDestroy } from "svelte";
     import { Readable, Writable } from "svelte/store";
     import MultiSelect from "../MultiSelect.svelte";
     import { MultiSelectModel } from "../MultiSelectModel";
@@ -9,7 +12,21 @@
     export let app: App;
     export let errors: Readable<string[]>;
     export let value: Writable<FieldValue>;
-    $: model = MultiSelectModel(input, app, value as Writable<string[]>);
+    export let form: FormEngine;
+
+    let formValues: Record<string, unknown> = {};
+    const unsubscribe = form.subscribe((formData) => {
+        formValues = pipe(
+            formData.fields,
+            R.filterMap((field) => field.value),
+        );
+    });
+
+    onDestroy(unsubscribe);
+
+    $: model = MultiSelectModel(input, app, value as Writable<string[]>, {
+        getFormData: () => formValues,
+    });
     $: values = value as Writable<string[]>;
 </script>
 

--- a/src/views/components/Form/RenderField.svelte
+++ b/src/views/components/Form/RenderField.svelte
@@ -122,7 +122,13 @@
             required={definition.isRequired}
         >
             {#if definition.input.type === "multiselect"}
-                <MultiSelectField input={definition.input} {value} {errors} {app} />
+                <MultiSelectField
+                    input={definition.input}
+                    {value}
+                    {errors}
+                    {app}
+                    form={formEngine}
+                />
             {:else if definition.input.type === "slider"}
                 <InputSlider input={definition.input} {value} />
             {:else if definition.input.type === "tag"}

--- a/src/views/components/MultiSelectModel.test.ts
+++ b/src/views/components/MultiSelectModel.test.ts
@@ -1,0 +1,13 @@
+jest.mock("obsidian");
+
+import { replaceRemainingOptions } from "./MultiSelectModel";
+
+describe("replaceRemainingOptions", () => {
+    it("refreshes dataview options without re-adding selected values", () => {
+        const remainingOptions = new Set(["old", "selected"]);
+
+        replaceRemainingOptions(remainingOptions, ["selected", "next", "other"], ["selected"]);
+
+        expect([...remainingOptions]).toEqual(["next", "other"]);
+    });
+});

--- a/src/views/components/MultiSelectModel.ts
+++ b/src/views/components/MultiSelectModel.ts
@@ -1,21 +1,44 @@
 import { A, pipe } from "@std";
 import { absurd } from "fp-ts/function";
 import { App } from "obsidian";
-import { getMultiselectNoteFolders, inputTag, multiselect } from "src/core/input/InputDefinitionSchema";
+import {
+    getMultiselectNoteFolders,
+    inputTag,
+    multiselect,
+} from "src/core/input/InputDefinitionSchema";
 import { executeSandboxedDvQuery, sandboxedDvQuery } from "src/suggesters/SafeDataviewQuery";
 import { StringSuggest } from "src/suggesters/StringSuggest";
 import { FileSuggest } from "src/suggesters/suggestFile";
 import { Writable, get } from "svelte/store";
+
+type FormData = Record<string, unknown>;
+
+type MultiSelectModelOptions = {
+    getFormData?: () => FormData;
+};
 
 export interface MultiSelectModel {
     createInput(element: HTMLInputElement): void;
     removeValue(value: string): void;
 }
 
+export function replaceRemainingOptions(
+    remainingOptions: Set<string>,
+    options: string[],
+    selectedValues: string[],
+): void {
+    const selected = new Set(selectedValues);
+    remainingOptions.clear();
+    options
+        .filter((option) => !selected.has(option))
+        .forEach((option) => remainingOptions.add(option));
+}
+
 export async function MultiSelectModel(
     fieldInput: multiselect,
     app: App,
     values: Writable<string[]>,
+    options: MultiSelectModelOptions = {},
 ): Promise<MultiSelectModel> {
     const source = fieldInput.source;
     const removeValue = (value: string) =>
@@ -26,13 +49,40 @@ export async function MultiSelectModel(
             ),
         );
     switch (source) {
-        case "dataview":
+        case "dataview": {
+            const remainingOptions = new Set<string>();
+            const query = sandboxedDvQuery(fieldInput.query);
+            const refreshOptions = async () => {
+                const results = await executeSandboxedDvQuery(
+                    query,
+                    app,
+                    options.getFormData?.() ?? {},
+                )();
+                replaceRemainingOptions(remainingOptions, results, get(values) ?? []);
+            };
+            await refreshOptions();
+            return {
+                createInput(element: HTMLInputElement) {
+                    new StringSuggest(
+                        element,
+                        remainingOptions,
+                        (selected) => {
+                            remainingOptions.delete(selected);
+                            values.update((x) => [...x, selected]);
+                        },
+                        app,
+                        fieldInput.allowUnknownValues,
+                        refreshOptions,
+                    );
+                },
+                removeValue(value: string) {
+                    removeValue(value);
+                    void refreshOptions();
+                },
+            };
+        }
         case "fixed": {
-            const remainingOptions = new Set(
-                source === "fixed"
-                    ? fieldInput.multi_select_options
-                    : await executeSandboxedDvQuery(sandboxedDvQuery(fieldInput.query), app)(),
-            );
+            const remainingOptions = new Set(fieldInput.multi_select_options);
             return {
                 createInput(element: HTMLInputElement) {
                     new StringSuggest(


### PR DESCRIPTION
## Summary
- pass the current form engine values into multiselect field models
- refresh dataview-backed multiselect options when suggestions are requested
- keep already-selected values out of refreshed suggestion sets

Fixes #436.

## Verification
- eslint src
- 	sc --noEmit
- svelte-check --tsconfig tsconfig.json *(reports existing src/main.ts class-property diagnostic and existing Svelte warnings unrelated to this change)*

## Notes
- Added a focused unit test for refreshed multiselect option handling.
- jest src/views/components/MultiSelectModel.test.ts --runInBand could not start in this local pnpm install because Jest requires 	s-node for jest.config.ts, but 	s-node is not listed in the installed dependencies.