### PR TITLE
Prevent stale markdown block renders

### DIFF
--- a/src/views/components/Form/MarkdownBlock.svelte
+++ b/src/views/components/Form/MarkdownBlock.svelte
@@ -26,10 +26,11 @@
     function generateContent(
         parent: HTMLElement,
         form: GetSubscription<Parameters<FormEngine["subscribe"]>[0]>,
-        execute = false,
     ) {
-        if (execute) {
-            parent.innerHTML = "";
+        let renderVersion = 0;
+
+        function renderMarkdown(form: GetSubscription<Parameters<FormEngine["subscribe"]>[0]>) {
+            const currentRender = ++renderVersion;
             pipe(
                 functionParsed,
                 TE.fromEither,
@@ -42,16 +43,26 @@
                 ),
                 TE.match(
                     (error) => {
+                        if (currentRender !== renderVersion) return;
+                        parent.replaceChildren();
                         console.error(error);
                         notifyError("Error in markdown block")(String(error));
                     },
-                    (newText) => MarkdownRenderer.render(app, newText, parent, "/", component),
+                    async (newText) => {
+                        const nextContent = document.createElement("div");
+                        await MarkdownRenderer.render(app, newText, nextContent, "/", component);
+                        if (currentRender !== renderVersion) return;
+                        parent.replaceChildren(...Array.from(nextContent.childNodes));
+                    },
                 ),
             )();
         }
+
+        renderMarkdown(form);
+
         return {
             update(newForm: GetSubscription<Parameters<FormEngine["subscribe"]>[0]>) {
-                generateContent(parent, newForm, true);
+                renderMarkdown(newForm);
             },
         };
     }


### PR DESCRIPTION
## Summary
- render markdown block content into a detached container before swapping it into the live DOM
- track render versions so older async markdown renders cannot append stale content after a newer form update
- render the initial form state through the same guarded path as subsequent updates

Fixes #373.

## Root cause
Markdown blocks re-render as the form store updates. Because MarkdownRenderer.render is asynchronous, an older render can finish after a newer update has already cleared and rendered the block, leaving duplicated markdown content in the block container.

## Verification
- eslint src
- 	sc --noEmit
- svelte-check --tsconfig tsconfig.json *(reports existing src/main.ts class-property diagnostic and existing Svelte warnings unrelated to this change)*