### PR TITLE
feat: add `oneline` template transformation

### DIFF
--- a/docs/ResultValue.md
+++ b/docs/ResultValue.md
@@ -88,7 +88,7 @@ The above code will print the list field as a bullet list, but all the values wi
 The map method takes a function that takes the value and returns a new value.
 It can be used when none of the provided printing are enough for your use case, or when one of them is almost what you need but you need to transform the value a bit more.
 
-### `trimmed`,`lower`,`upper`,`capitalized`,`slug` shortcuts
+### `trimmed`,`lower`,`upper`,`capitalized`,`slug`,`oneline` shortcuts
 
 The ResultValue class provides some shortcuts to common transformations of the value.
 They are:
@@ -98,6 +98,7 @@ They are:
 - `upper`: Converts the value to uppercase.
 - `capitalized`: Uppercases the first character and leaves the rest untouched. Chain after `lower` (e.g. `result.getValue('name').lower.capitalized`) if you also want the remaining characters lowercased.
 - `slug`: Converts the value to a URL/filename-friendly slug. Lowercases the value, turns whitespace and underscores into `-`, strips punctuation, collapses runs of dashes, and trims edge dashes. Unicode letters/numbers are preserved so `Café Noël` becomes `café-noël`. Handy for turning a form's title into a filename: `result.getValue('title').slug`.
+- `oneline`: Collapses any run of whitespace (spaces, tabs, newlines) into a single space and trims the edges. Handy when you want to drop a textarea into a single-line YAML frontmatter entry, e.g. `result.getValue('summary').oneline`.
 
 All of these shortcuts return a new ResultValue object, so you can chain them with other methods.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -107,6 +107,16 @@ The following transformations can be applied to variables:
 
    - Input `Hello, World!` produces `hello-world`; input `  My Note (2024)  ` produces `my-note-2024`.
 
+7. **`oneline`**: Collapses any run of whitespace (spaces, tabs, newlines) into a single space and trims the edges.
+   - Handy when a multi-line textarea has to fit on a single line — for example a `description` field embedded in YAML frontmatter, where an unquoted newline would break the block.
+   - Usage:
+
+     ```plaintext
+     description: {{ notes | oneline }}
+     ```
+
+   - Input `"line one\nline two\nline three"` produces `line one line two line three`; input `"  hello\t\tworld  \n\n  from   here  "` produces `hello world from here`.
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/src/core/FormResult.ts
+++ b/src/core/FormResult.ts
@@ -75,7 +75,8 @@ export default class FormResult {
      * Variables use the `{{ key }}` syntax. Optional whitespace is allowed
      * around the key, and a transformation can be applied with `|`, e.g.
      * `{{ key | upper }}`. Supported transformations match the ones used by
-     * form templates: `upper`, `lower`, `trim`, `stringify`, `capitalize`.
+     * form templates: `upper`, `lower`, `trim`, `stringify`, `capitalize`,
+     * `slug`, `oneline`.
      * Unknown keys are left untouched (the literal `{{ key }}` stays in the
      * output) so users can spot typos easily.
      */

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -344,6 +344,32 @@ describe("ResultValue", () => {
             expect(resultValue.trimmed.slug.toString()).toEqual("hello-world");
         });
     });
+    describe("oneline", () => {
+        it("should collapse newlines into single spaces", () => {
+            const resultValue = ResultValue.from("line one\nline two\nline three", "Test");
+            expect(resultValue.oneline.toString()).toEqual("line one line two line three");
+        });
+        it("should collapse tabs and multiple spaces", () => {
+            const resultValue = ResultValue.from("  hello\t\tworld   from   here  ", "Test");
+            expect(resultValue.oneline.toString()).toEqual("hello world from here");
+        });
+        it("should collapse each string in an array individually", () => {
+            const resultValue = ResultValue.from(["foo\nbar", "baz\tqux"], "Test");
+            expect(resultValue.oneline.toString()).toEqual("foo bar, baz qux");
+        });
+        it("should leave non-string values unchanged in mixed arrays", () => {
+            const resultValue = ResultValue.from(["foo\nbar", 42], "Test");
+            expect(resultValue.oneline.bullets).toEqual("- foo bar\n- 42");
+        });
+        it("should handle an empty string without crashing", () => {
+            const resultValue = ResultValue.from("", "Test");
+            expect(resultValue.oneline.toString()).toEqual("");
+        });
+        it("should be chainable", () => {
+            const resultValue = ResultValue.from("  hello\nworld  ", "Test");
+            expect(resultValue.oneline.upper.toString()).toEqual("HELLO WORLD");
+        });
+    });
     describe("chaining shortcuts", () => {
         it("should be possible to chain upper, lower and trim", () => {
             // Arrange

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -1,7 +1,7 @@
 import { E, O, ensureError, pipe } from "@std";
 import { notifyError } from "src/utils/Log";
 import { FileProxy } from "./files/FileProxy";
-import { toSlug } from "./template/templateParser";
+import { toOneLine, toSlug } from "./template/templateParser";
 
 function _toBulletList(value: Record<string, unknown> | unknown[]) {
     if (Array.isArray(value)) {
@@ -228,6 +228,21 @@ export class ResultValue<T = unknown> {
             return new ResultValue(toSlug(this.value.name), this.name, this.notify);
         }
         return this.map((v) => deepMap(v, (it) => (typeof it === "string" ? toSlug(it) : it)));
+    }
+
+    /**
+     * getter that collapses any run of whitespace (spaces, tabs, newlines) in
+     * each string into a single space and trims the edges. Handy when you want
+     * to drop a textarea value into a single-line YAML frontmatter entry, or
+     * anywhere else newlines would break the surrounding format. Strings
+     * nested in arrays/objects are collapsed individually; non-string values
+     * are returned unchanged.
+     */
+    get oneline(): ResultValue<unknown> {
+        if (this.value instanceof FileProxy) {
+            return new ResultValue(toOneLine(this.value.name), this.name, this.notify);
+        }
+        return this.map((v) => deepMap(v, (it) => (typeof it === "string" ? toOneLine(it) : it)));
     }
 
     /**

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -292,6 +292,42 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("[]"));
     });
 
+    it("Should execute a template with oneline transformation", () => {
+        const template = "{{notes|oneline}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { notes: "line one\nline two\nline three" }),
+            ),
+        );
+        expect(result).toEqual(E.of("line one line two line three"));
+    });
+
+    it("oneline collapses tabs, spaces and multiple newlines", () => {
+        const template = "{{notes|oneline}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, {
+                    notes: "  hello\t\tworld\n\n  from   here  ",
+                }),
+            ),
+        );
+        expect(result).toEqual(E.of("hello world from here"));
+    });
+
+    it("oneline handles an empty string without crashing", () => {
+        const template = "[{{notes|oneline}}]";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { notes: "" })),
+        );
+        expect(result).toEqual(E.of("[]"));
+    });
+
     it("should parse a frontmatter command", () => {
         const template = "{#frontmatter#}";
         const result = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -251,6 +251,13 @@ export function toSlug(value: string): string {
         .replace(/^-+|-+$/g, "");
 }
 
+// Collapses any run of whitespace (spaces, tabs, newlines) into a single space
+// and trims the edges. Useful for putting textarea content into single-line
+// YAML frontmatter or anywhere newlines would break the surrounding format.
+export function toOneLine(value: string): string {
+    return value.replace(/\s+/g, " ").trim();
+}
+
 export function executeTransformation(
     transformation: Transformations | undefined,
 ): (value: Val) => string {
@@ -274,6 +281,8 @@ export function executeTransformation(
             }
             case "slug":
                 return toSlug(String(value));
+            case "oneline":
+                return toOneLine(String(value));
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -24,6 +24,7 @@ export const transformations = union([
     literal("stringify"),
     literal("capitalize"),
     literal("slug"),
+    literal("oneline"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds an `oneline` template transformation that collapses any run of whitespace (spaces, tabs, newlines) in a value into a single space and trims the edges. This targets a very common pain point: dropping a multi-line textarea into single-line contexts — a YAML frontmatter entry, a Dataview inline field, a heading, etc. — where a stray newline would break the surrounding block.

Wired into the same three entry points as the recent `slug` / `capitalize` additions so it works everywhere transformations already work:

- `{{ field | oneline }}` inside form templates
- `FormResult.asString('description: {{ notes | oneline }}')`
- `result.getValue('summary').oneline` (chainable getter on `ResultValue`)

Strings nested in arrays/objects are collapsed individually; non-string values pass through unchanged. `FileProxy` values are collapsed from the file name for consistency with `slug`/`capitalized`.

## Behavior

| Input | Output |
| --- | --- |
| `line one\nline two\nline three` | `line one line two line three` |
| `  hello\t\tworld  \n\n  from   here  ` | `hello world from here` |
| `""` (empty) | `""` |
| `["foo\nbar", "baz\tqux"]` | `foo bar, baz qux` |

Composes with the other shortcuts: `result.getValue('notes').oneline.upper` → single-line, uppercased.

## Changes

- **`src/core/template/templateSchema.ts`** — add `literal("oneline")` to the transformations union.
- **`src/core/template/templateParser.ts`** — export a `toOneLine` helper (reused by `ResultValue`) and handle the new case in `executeTransformation`.
- **`src/core/ResultValue.ts`** — add an `oneline` getter that mirrors the shape of `slug`/`capitalized` (deep-maps into arrays/objects, handles `FileProxy`).
- **`src/core/FormResult.ts`** — update the `asString` docstring to list the new transformation.
- **`src/core/template/templateParser.test.ts`** — 3 new parser tests.
- **`src/core/ResultValue.test.ts`** — 6 new `ResultValue.oneline` tests.
- **`docs/templates.md`** — document the new pipe transformation with input/output examples.
- **`docs/ResultValue.md`** — document the new getter.

## Test plan

- [x] `npm run test` — 210 pass (was 201, +9 new); 2 pre-existing skipped
- [x] `npm run build` — `svelte-check found 0 errors`; only the 5 pre-existing warnings (Toggle a11y ×2, unused `.clear-button` / `.clear-button:hover` CSS)
- [ ] Manual: on the preview URL, drop a multi-line textarea into a frontmatter entry via `{{ notes | oneline }}` and confirm the resulting note has a valid single-line YAML value
- [ ] Manual: chain `result.getValue('summary').oneline.upper` from a Templater snippet and confirm the output is single-line and uppercased

---
_Generated by [Claude Code](https://claude.ai/code/session_01Psbt838FNaGV32PZXpjqna)_