### PR TITLE
feat: allow referencing form fields on image filename templates

### DIFF
--- a/docs/FormBuilder.md
+++ b/docs/FormBuilder.md
@@ -243,10 +243,26 @@ builder("example-avatar-form")
   .image({ 
     name: "avatar", 
     label: "Avatar",
-    filenameTemplate: "avatar-${date}",
+    filenameTemplate: "avatar-{{date}}",
     saveLocation: "assets/images" 
   })
 ```
+
+The `filenameTemplate` accepts the following placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{{date}}` | Current date, as `YYYY-MM-DD` |
+| `{{time}}` | Current time, as `HH-mm-ss` |
+| `{{datetime}}` | Current date and time, as `YYYY-MM-DD-HH-mm-ss` |
+| `{{anyFieldName}}` | The value of any other field of the same form |
+
+Field placeholders are resolved when the image is picked, using whatever the form
+holds at that moment, so `{{name}} - new member` saves the image as
+`Jane Doe - new member.png` when the `name` field contains `Jane Doe`.
+Multi valued fields (multiselect, tags) are joined with a dash, file fields use their
+name without extension, and fields that are still empty resolve to an empty text.
+The date placeholders take precedence, so a field named `date` does not shadow `{{date}}`.
 
 ### file
 

--- a/src/core/input/imageFilenameTemplate.test.ts
+++ b/src/core/input/imageFilenameTemplate.test.ts
@@ -1,0 +1,83 @@
+import { FileProxy } from "../files/FileProxy";
+import { createFilename, processTemplate, sanitizeFilename } from "./imageFilenameTemplate";
+
+const now = new Date(2024, 11, 8, 19, 29, 52);
+
+describe("processTemplate", () => {
+    it("replaces the built-in date placeholders", () => {
+        expect(processTemplate("{{date}}", {}, now)).toBe("2024-12-08");
+        expect(processTemplate("{{time}}", {}, now)).toBe("19-29-52");
+        expect(processTemplate("{{datetime}}", {}, now)).toBe("2024-12-08-19-29-52");
+    });
+
+    it("tolerates whitespace inside the placeholder", () => {
+        expect(processTemplate("{{ datetime }}", {}, now)).toBe("2024-12-08-19-29-52");
+        expect(processTemplate("{{  name  }}", { name: "Jane" }, now)).toBe("Jane");
+    });
+
+    it("replaces every occurrence of a placeholder", () => {
+        expect(processTemplate("{{date}}-{{date}}", {}, now)).toBe("2024-12-08-2024-12-08");
+        expect(processTemplate("{{name}}-{{name}}", { name: "Jane" }, now)).toBe("Jane-Jane");
+    });
+
+    it("replaces placeholders with the value of the form field of the same name", () => {
+        expect(processTemplate("{{name}} - new member", { name: "Jane Doe" }, now)).toBe(
+            "Jane Doe - new member",
+        );
+    });
+
+    it("renders non string field values", () => {
+        const values = { age: 42, active: true, tags: ["one", "two"] };
+        expect(processTemplate("{{age}}-{{active}}-{{tags}}", values, now)).toBe(
+            "42-true-one-two",
+        );
+    });
+
+    it("renders file fields using their name without extension", () => {
+        const file = new FileProxy({
+            path: "attachments/avatar.png",
+            name: "avatar.png",
+            basename: "avatar",
+            extension: "png",
+        });
+        expect(processTemplate("{{avatar}}", { avatar: file }, now)).toBe("avatar");
+    });
+
+    it("resolves unknown placeholders to an empty string", () => {
+        expect(processTemplate("a-{{missing}}-b", { name: "Jane" }, now)).toBe("a--b");
+    });
+
+    it("keeps the built-in placeholders when a field shares their name", () => {
+        expect(processTemplate("{{date}}", { date: "not a date" }, now)).toBe("2024-12-08");
+    });
+
+    it("leaves templates without placeholders untouched", () => {
+        expect(processTemplate("just-an-image", {}, now)).toBe("just-an-image");
+    });
+});
+
+describe("sanitizeFilename", () => {
+    it("replaces the characters that are invalid on a filename", () => {
+        expect(sanitizeFilename('a<b>c:d"e/f\\g|h?i*j')).toBe("a-b-c-d-e-f-g-h-i-j");
+    });
+});
+
+describe("createFilename", () => {
+    it("sanitizes the values coming from the form", () => {
+        expect(createFilename("{{name}}", { name: "folder/name" }, now)).toBe("folder-name");
+    });
+
+    it("trims the result", () => {
+        expect(createFilename("  {{name}}  ", { name: "Jane" }, now)).toBe("Jane");
+    });
+
+    it("falls back to a datetime filename when everything resolves to nothing", () => {
+        expect(createFilename("{{missing}}", {}, now)).toBe("2024-12-08-19-29-52");
+    });
+
+    it("works without form values, as it did before field placeholders existed", () => {
+        expect(createFilename("image-{{datetime}}")).toMatch(
+            /^image-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/,
+        );
+    });
+});

--- a/src/core/input/imageFilenameTemplate.test.ts
+++ b/src/core/input/imageFilenameTemplate.test.ts
@@ -47,6 +47,13 @@ describe("processTemplate", () => {
         expect(processTemplate("a-{{missing}}-b", { name: "Jane" }, now)).toBe("a--b");
     });
 
+    it("resolves inherited object properties to an empty string", () => {
+        // `name in object` would report these as present and resolve them to
+        // members of Object.prototype, so they need an own property check
+        const template = "a-{{__proto__}}-{{toString}}-{{constructor}}-b";
+        expect(processTemplate(template, {}, now)).toBe("a----b");
+    });
+
     it("keeps the built-in placeholders when a field shares their name", () => {
         expect(processTemplate("{{date}}", { date: "not a date" }, now)).toBe("2024-12-08");
     });

--- a/src/core/input/imageFilenameTemplate.ts
+++ b/src/core/input/imageFilenameTemplate.ts
@@ -1,32 +1,72 @@
 import { pipe } from "@std";
-const moment = window.moment
+import { FileProxy } from "../files/FileProxy";
+import type { ModalFormData, Val } from "../formResultTypes";
 
 export interface FilenameTemplate {
     template: string;
 }
 
-type PlaceholderFn = () => string;
+/** Matches `{{ placeholder }}`, tolerating any amount of surrounding whitespace */
+const PLACEHOLDER_RE = /\{\{\s*([^{}]*?)\s*\}\}/g;
 
-const placeholders: Record<string, PlaceholderFn> = {
-    "{{date}}": () => moment().format("YYYY-MM-DD"),
-    "{{time}}": () => moment().format("HH-mm-ss"),
-    "{{datetime}}": () => moment().format("YYYY-MM-DD-HH-mm-ss"),
-};
+/** Separator used to flatten multi valued fields (multiselect, tags) into a filename */
+const LIST_SEPARATOR = "-";
+
+function pad(n: number): string {
+    return String(n).padStart(2, "0");
+}
+
+const formatDate = (now: Date) =>
+    `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+const formatTime = (now: Date) =>
+    `${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+const formatDatetime = (now: Date) => `${formatDate(now)}-${formatTime(now)}`;
 
 /**
- * Replaces placeholders in a template string with their corresponding values
+ * Placeholders that are always available, regardless of the form contents.
+ * They take precedence over form fields to avoid breaking existing templates.
+ */
+const datePlaceholders = {
+    date: formatDate,
+    time: formatTime,
+    datetime: formatDatetime,
+} satisfies Record<string, (now: Date) => string>;
+
+function isDatePlaceholder(name: string): name is keyof typeof datePlaceholders {
+    return name in datePlaceholders;
+}
+
+/**
+ * Renders a form value as a filename friendly string.
+ * Lists are joined with a dash, files are represented by their name without extension.
+ */
+function valueToString(value: Val): string {
+    if (Array.isArray(value)) return value.map(String).join(LIST_SEPARATOR);
+    if (value instanceof FileProxy) return value.basename;
+    return String(value);
+}
+
+/**
+ * Replaces placeholders in a template string with their corresponding values.
+ * Besides the built-in date placeholders, any field of the form can be referenced
+ * by name, so a template like `{{ name }} - new member` renders using the value
+ * the user typed on the `name` field.
  * @param template The template string containing placeholders
+ * @param values The current form values, used to resolve field placeholders
+ * @param now The date used to resolve the date placeholders. Defaults to the current time
  * @returns A string with all placeholders replaced with their values
  */
-export function processTemplate(template: string): string {
-    return pipe(
-        template,
-        (tmpl) =>
-            Object.entries(placeholders).reduce(
-                (acc, [placeholder, fn]) => acc.replace(placeholder, fn()),
-                tmpl
-            )
-    );
+export function processTemplate(
+    template: string,
+    values: ModalFormData = {},
+    now: Date = new Date(),
+): string {
+    return template.replace(PLACEHOLDER_RE, (_match, rawName: string) => {
+        const name = rawName.trim();
+        if (isDatePlaceholder(name)) return datePlaceholders[name](now);
+        const value = values[name];
+        return value === undefined ? "" : valueToString(value);
+    });
 }
 
 /**
@@ -39,13 +79,23 @@ export function sanitizeFilename(filename: string): string {
 }
 
 /**
- * Creates a filename from a template, replacing placeholders and sanitizing the result
+ * Creates a filename from a template, replacing placeholders and sanitizing the result.
+ * When the resulting filename is empty, because every placeholder resolved to an empty
+ * value, a datetime based filename is used instead, so we never save an extension-only file.
  * @param template The template containing placeholders
+ * @param values The current form values, used to resolve field placeholders
+ * @param now The date used to resolve the date placeholders. Defaults to the current time
  * @returns A valid filename with placeholders replaced
  */
-export function createFilename(template: string): string {
+export function createFilename(
+    template: string,
+    values: ModalFormData = {},
+    now: Date = new Date(),
+): string {
     return pipe(
-template, 
-processTemplate, 
-sanitizeFilename);
+        processTemplate(template, values, now),
+        sanitizeFilename,
+        (filename) => filename.trim(),
+        (filename) => (filename === "" ? formatDatetime(now) : filename),
+    );
 }

--- a/src/core/input/imageFilenameTemplate.ts
+++ b/src/core/input/imageFilenameTemplate.ts
@@ -32,8 +32,13 @@ const datePlaceholders = {
     datetime: formatDatetime,
 } satisfies Record<string, (now: Date) => string>;
 
+/** Own property check, so inherited names like `__proto__` or `toString` are not mistaken for keys */
+function hasOwn(object: object, name: string): boolean {
+    return Object.prototype.hasOwnProperty.call(object, name);
+}
+
 function isDatePlaceholder(name: string): name is keyof typeof datePlaceholders {
-    return name in datePlaceholders;
+    return hasOwn(datePlaceholders, name);
 }
 
 /**
@@ -64,6 +69,7 @@ export function processTemplate(
     return template.replace(PLACEHOLDER_RE, (_match, rawName: string) => {
         const name = rawName.trim();
         if (isDatePlaceholder(name)) return datePlaceholders[name](now);
+        if (!hasOwn(values, name)) return "";
         const value = values[name];
         return value === undefined ? "" : valueToString(value);
     });

--- a/src/store/formEngine.ts
+++ b/src/store/formEngine.ts
@@ -63,6 +63,12 @@ export interface FormEngine {
      */
     subscribe: Readable<FormStore<FieldValue>>["subscribe"];
     /**
+     * Returns the values the form holds right now, skipping the fields that have no value yet.
+     * Unlike the submit result, this is a snapshot of a possibly incomplete form,
+     * useful for fields that need to react to what the user typed on other fields.
+     */
+    getValues(): Record<string, FieldValue>;
+    /**
      * Readable store that represents the validity of the form.
      * If any of the fields in the form have errors, this will be false.
      */
@@ -245,6 +251,12 @@ export function makeFormEngine({
     return {
         subscribe: formStore.subscribe,
         errors,
+        getValues() {
+            return pipe(
+                get(formStore).fields,
+                R.filterMap((field) => field.value),
+            );
+        },
         isValid: derived(formStore, ({ fields }) =>
             pipe(
                 fields,

--- a/src/views/components/Form/ImageInputModel.ts
+++ b/src/views/components/Form/ImageInputModel.ts
@@ -2,6 +2,7 @@ import { E, pipe, TE } from "@std";
 import type { Either } from "fp-ts/Either";
 import { FileProxy } from "src/core/files/FileProxy";
 import { FileService } from "src/core/files/FileService";
+import type { ModalFormData } from "src/core/formResultTypes";
 import { createFilename } from "src/core/input/imageFilenameTemplate";
 import { type imageInput } from "src/core/input/InputDefinitionSchema";
 import { logger } from "src/utils/Logger";
@@ -18,6 +19,11 @@ export interface ImageInputModel {
 interface ImageInputModelDeps {
     input: imageInput;
     fileService: FileService;
+    /**
+     * Reads the values the form holds at the moment the image is saved,
+     * so the filename template can reference other fields of the same form.
+     */
+    getFormValues?: () => ModalFormData;
     l?: typeof logger;
 }
 
@@ -55,6 +61,7 @@ function getImageExtension(dataUrl: string): Either<Error, string> {
 export function makeImageInputModel({
     fileService,
     input,
+    getFormValues = () => ({}),
     l = logger,
 }: ImageInputModelDeps): ImageInputModel {
     const error = writable<string | null>(null);
@@ -82,7 +89,7 @@ export function makeImageInputModel({
 
             // Save the file
             TE.chainW(({ extension, bytes }) => {
-                const filename = createFilename(input.filenameTemplate);
+                const filename = createFilename(input.filenameTemplate, getFormValues());
                 return pipe(
                     fileService.saveFile(`${filename}.${extension}`, input.saveLocation, bytes.buffer),
                     TE.map((file) => new FileProxy(file)),

--- a/src/views/components/Form/RenderField.svelte
+++ b/src/views/components/Form/RenderField.svelte
@@ -96,7 +96,11 @@
             required={definition.isRequired}
         >
             {#if $value == null || $value instanceof FileProxy}
-                {@const imageModel = makeImageInputModel({ fileService, input: definition.input })}
+                {@const imageModel = makeImageInputModel({
+                    fileService,
+                    input: definition.input,
+                    getFormValues: () => formEngine.getValues(),
+                })}
                 <ImageInput id={definition.name} model={imageModel} bind:value={$value} />
             {/if}
         </ObsidianInputWrapper>

--- a/src/views/components/InputBuilderImage.svelte
+++ b/src/views/components/InputBuilderImage.svelte
@@ -29,6 +29,8 @@
     const date = "{{date}}";
     const time = "{{time}}";
     const datetime = "{{datetime}}";
+    const fieldName = "{{fieldName}}";
+    const fieldNameExample = "{{name}} - new member";
 </script>
 
 <div class="modal-form flex column gap1">
@@ -60,9 +62,18 @@
                 <li>
                     <code>{datetime}</code> - Current date and time (YYYY-MM-DD-HH-mm-ss)
                 </li>
+                <li>
+                    <code>{fieldName}</code> - The value of any other field of this form, using its
+                    name. Multi valued fields are joined with a dash, and fields left empty resolve
+                    to an empty text.
+                </li>
             </ul>
             Example:<code>screenshot-{datetime}.png</code> will create:
             <code>screenshot-2024-12-08-19-29-52.png</code>
+            <br />
+            Example: if this form has a <code>name</code> field,
+            <code>{fieldNameExample}</code> will create:
+            <code>Jane Doe - new member.png</code>
         </div>
     </FormRow>
 </div>


### PR DESCRIPTION
## What

Image filename templates only understood the built-in date placeholders (`{{date}}`, `{{time}}`, `{{datetime}}`), so there was no way to name a saved image after something the user typed on the form. Now any field of the same form can be referenced by name:

```
{{name}} - new member
```

saves the picked image as `Jane Doe - new member.png` when the `name` field contains `Jane Doe`.

Implements the request in discussion #422.

## How

- `processTemplate` / `createFilename` (`src/core/input/imageFilenameTemplate.ts`) now take the current form values and resolve any `{{ fieldName }}` against them.
  - Date placeholders keep precedence over form fields, so existing templates behave exactly as before even if a form has a field named `date`.
  - Lists (multiselect, tags) are joined with a dash, file fields render as their name without extension, numbers/booleans are stringified, and unknown or empty fields resolve to an empty text.
  - Placeholders now tolerate whitespace (`{{ datetime }}`, which the settings placeholder text already advertised but did not work) and are replaced on **every** occurrence rather than just the first.
  - A template that resolves to nothing now falls back to a datetime filename instead of saving an extension-only file.
  - `window.moment` was swapped for plain `Date` formatting so the module is testable under Jest. The three formats are byte-for-byte the same.
- `FormEngine` gained `getValues()`, a snapshot of the values the form holds right now (skipping fields with no value yet).
- `ImageInputModel` takes an optional `getFormValues` dependency and reads it at save time, so the filename reflects what the user had typed when the image was picked. `RenderField.svelte` wires it to the form engine.
- Settings hint (`InputBuilderImage.svelte`) and `docs/FormBuilder.md` document the new placeholder. The docs example also had a wrong `${date}` syntax, corrected to `{{date}}`.

## Testing

- New `src/core/input/imageFilenameTemplate.test.ts` covering date placeholders, whitespace tolerance, repeated placeholders, non-string/list/file values, unknown fields, precedence, sanitization and the empty-template fallback.
- `npm run build` (lint + svelte-check + bundle) passes.
- `npm run test` passes: 14 suites, 223 passed / 2 skipped.
