### PR TITLE
fix: resolve Templater lazily so its syntax is processed in templates

### DIFF
--- a/src/core/template/getTemplateService.test.ts
+++ b/src/core/template/getTemplateService.test.ts
@@ -1,0 +1,62 @@
+jest.mock("obsidian");
+import { App } from "obsidian";
+import { Logger } from "src/utils/Logger";
+import { BasicTemplateService } from "./BasicTemplateService";
+import { getTemplateService, makeTemplateServiceResolver } from "./getTemplateService";
+import { TemplaterApi, TemplaterService } from "./TemplaterService";
+
+const logger = Logger.getInstance();
+
+const templaterApi: TemplaterApi = {
+    create_new_note_from_template: jest.fn(),
+    overwrite_file_commands: jest.fn(),
+};
+
+/**
+ * Minimal app stub exposing only what the resolver reads.
+ * `templater` starts undefined, mimicking Templater not being loaded yet.
+ */
+function makeApp(): App & { loadTemplater: () => void } {
+    const plugins: Record<string, unknown> = {};
+    const app = {
+        plugins: { enabledPlugins: new Set<string>(), plugins },
+        loadTemplater() {
+            plugins["templater-obsidian"] = { templater: templaterApi };
+        },
+    };
+    return app as unknown as App & { loadTemplater: () => void };
+}
+
+describe("getTemplateService", () => {
+    it("returns the basic service when Templater is not available", () => {
+        expect(getTemplateService(makeApp(), logger)).toBeInstanceOf(BasicTemplateService);
+    });
+
+    it("returns the Templater service when Templater is available", () => {
+        const app = makeApp();
+        app.loadTemplater();
+        expect(getTemplateService(app, logger)).toBeInstanceOf(TemplaterService);
+    });
+});
+
+describe("makeTemplateServiceResolver", () => {
+    it("picks up Templater when it loads after the resolver was created", () => {
+        const app = makeApp();
+        const resolve = makeTemplateServiceResolver(app, logger);
+
+        // Templater has not exposed its API yet, we can only offer the basic service
+        expect(resolve()).toBeInstanceOf(BasicTemplateService);
+
+        app.loadTemplater();
+
+        expect(resolve()).toBeInstanceOf(TemplaterService);
+    });
+
+    it("caches the Templater service once resolved", () => {
+        const app = makeApp();
+        app.loadTemplater();
+        const resolve = makeTemplateServiceResolver(app, logger);
+
+        expect(resolve()).toBe(resolve());
+    });
+});

--- a/src/core/template/getTemplateService.ts
+++ b/src/core/template/getTemplateService.ts
@@ -14,3 +14,30 @@ export function getTemplateService(app: App, logger: Logger): TemplateService {
     logger.debug("Using basic template service");
     return new BasicTemplateService(app, logger);
 }
+
+/**
+ * Builds a resolver that returns the template service to use at the moment it is called.
+ *
+ * Resolving the service eagerly (for example, when our plugin loads) is not reliable:
+ * Obsidian enables plugins in the order they appear in `community-plugins.json`, and
+ * Templater only exposes its API partway through its own `onload`. If we happen to load
+ * first we would see no Templater and silently fall back to the basic service for the
+ * rest of the session, leaving templater syntax unprocessed in every template.
+ *
+ * By resolving lazily we pick Templater up as soon as it becomes available. Once we get
+ * a Templater backed service we cache it, since Templater cannot disappear without a
+ * plugin reload, but we keep re-checking while we only have the basic fallback.
+ */
+export function makeTemplateServiceResolver(app: App, logger: Logger): () => TemplateService {
+    let templaterService: TemplateService | undefined;
+    return () => {
+        if (templaterService !== undefined) {
+            return templaterService;
+        }
+        const service = getTemplateService(app, logger);
+        if (service instanceof TemplaterService) {
+            templaterService = service;
+        }
+        return service;
+    };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,10 @@ import {
     MigrationError,
 } from "./core/formDefinitionSchema";
 import { TemplateService } from "./core/template/TemplateService";
-import { getTemplateService } from "./core/template/getTemplateService";
+import {
+    getTemplateService,
+    makeTemplateServiceResolver,
+} from "./core/template/getTemplateService";
 import { retryForm } from "./core/template/retryForm";
 import { executeTemplate } from "./core/template/templateParser";
 import { settingsStore } from "./store/SettngsStore";
@@ -63,7 +66,16 @@ export default class ModalFormPlugin extends Plugin {
     private unsubscribeSettingsStore: () => void = () => {};
     // This things will be setup in the onload function rather than constructor
     public api!: API;
-    private templateService!: TemplateService;
+    /**
+     * Resolves the template service on every access, so we pick up Templater
+     * even when it finishes loading after us. See `makeTemplateServiceResolver`.
+     */
+    private resolveTemplateService: () => TemplateService = () =>
+        getTemplateService(this.app, logger);
+
+    private get templateService(): TemplateService {
+        return this.resolveTemplateService();
+    }
 
     manageForms() {
         return this.activateView(MANAGE_FORMS_VIEW);
@@ -313,7 +325,7 @@ export default class ModalFormPlugin extends Plugin {
         });
         this.api = new API(this.app, this);
         this.attachShortcutToGlobalWindow();
-        this.templateService = getTemplateService(this.app, logger);
+        this.resolveTemplateService = makeTemplateServiceResolver(this.app, logger);
 
         // Register template commands at startup
         this.registerTemplateCommands();


### PR DESCRIPTION
Closes #411

## The bug

`getTemplateService` was called exactly once, from `onload`:

```ts
this.templateService = getTemplateService(this.app, logger);
```

and it decides which service to use by reading:

```ts
const templaterApi = app.plugins.plugins["templater-obsidian"]?.templater;
```

Obsidian enables plugins in the order they appear in `community-plugins.json`, and Templater only assigns `this.templater = new Templater(this)` partway through its own `onload`. Whenever Modal Form loads before Templater, that lookup finds nothing and we bind `BasicTemplateService` **for the entire session**.

`BasicTemplateService` writes the note content verbatim and its `replaceVariablesInFile` is a literal no-op, so templater syntax is left untouched in:

- `Insert template: <form>` and `Insert form template` (the `replaceVariablesInFile` call after saving does nothing)
- `Create note from template: <form>` and `Create new note from a form` (`vault.create` with the raw content)

Because it depends only on plugin ordering, it reproduces for some vaults and not others. This repo's own `EXAMPLE_VAULT/.obsidian/community-plugins.json` has `modalforms` listed before `templater-obsidian`, which is the broken order.

### Why it isn't a template syntax error on the user's side

If Templater *had* run and failed to parse, `create_new_note_from_template` deletes the created note and returns `undefined`, which `TemplaterService` already detects and turns into the retry form. Reporters instead get a note containing the raw `<% ... %>` text and no retry form, including for trivially valid snippets like `<% "---" %>` — Templater was never invoked.

## The fix

Resolve the service at the moment it is used instead of at load time, via a new `makeTemplateServiceResolver`. It re-checks for Templater while only the basic fallback is available, and caches the service once Templater is actually there (Templater cannot vanish without a plugin reload). `main.ts` keeps a `templateService` getter, so every existing call site is unchanged.

## Testing

- New `src/core/template/getTemplateService.test.ts` covers both services being selected correctly, the resolver picking up Templater when it loads *after* the resolver was created, and the caching behaviour.
- `npm run build` and `npm run test` pass locally (230 tests).

Not verified against a real Obsidian vault — the diagnosis is derived from the plugin load-order behaviour and Templater's source.

## Noted but not changed

`setImmediate(this.templateService.replaceVariablesInFile(file))` (`src/main.ts`, both insert commands) discards the `Left` and relies on `setImmediate`, which does not exist on Obsidian mobile. Worth a separate fix.
