### PR TITLE
feat: recover form data when a form is closed or a template fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This plugin for [Obsidian](https://obsidian.md) allows you to define forms that 
 - Create new notes directly from the form using templates
   - Template editor has a nice UI for creating templates
 - **Register commands for your forms:** Instantly trigger any form (with a template) from the command palette—no need for QuickAdd or external templates for simple use cases
+- **Never lose what you typed:** if a form is closed by accident or a template fails, you get a clear error and the form reopens with your data. See [Data recovery](docs/data-recovery.md)
 - Many input types
   - number
   - date
@@ -262,6 +263,18 @@ You can enhance your forms with templates, allowing you to generate dynamic note
 This makes it easy to trigger forms and use their templates anywhere with just a command—perfect for quick note creation or structured data capture.
 
 For details on template syntax and advanced features, see the [Templates documentation](docs/templates.md).
+
+### When something goes wrong
+
+Templates fail: a typo in a Templater command, a folder that does not exist, a
+value that is not what the template expected. When that happens after you filled
+a form, Modal Form shows you the actual error and offers to reopen the form with
+everything you had typed, so nothing has to be retyped. Data is also kept when a
+form is closed by accident, and can be brought back at any time with the
+`Modal Forms: Recover form data` command.
+
+See [Data recovery](docs/data-recovery.md) for the details, including how to opt
+out.
 
 ### Tips and tricks
 

--- a/docs/data-recovery.md
+++ b/docs/data-recovery.md
@@ -24,10 +24,17 @@ the 25 most recent forms. You can also turn the whole thing off in
 **Settings → Modal Form → Preserve form data**, which deletes everything kept
 so far.
 
-Data is tracked per form *and* per set of fields. A form opened through
-[`limitedForm`](../README.md#call-the-form-from-javascript) with `pick` or
-`omit` is a different shape than the full form, so it gets its own saved data
-and can never truncate or delete what the full form had.
+Data is tracked per form *and* per shape — the set of fields it has and their
+input types. Two consequences:
+
+- A form opened through
+  [`limitedForm`](../README.md#call-the-form-from-javascript) with `pick` or
+  `omit` is a different shape than the full form, so it gets its own saved data
+  and can never truncate or delete what the full form had.
+- Editing a form invalidates data saved for the old version of it, so a value
+  you typed into a text field is never poured into the number field that
+  replaced it. Nothing is deleted: that data is still there under
+  **Recover form data**, it just stops coming back on its own.
 
 ## When it comes back
 

--- a/docs/data-recovery.md
+++ b/docs/data-recovery.md
@@ -1,0 +1,78 @@
+# Never lose what you typed
+
+Filling a long form and then losing everything because a template had a typo,
+because Templater choked on a command, or because the modal was dismissed by
+accident, is the most annoying way this plugin can fail you. Modal Form keeps a
+copy of what you type so that never costs you more than a couple of clicks.
+
+## What is kept, and where
+
+While a form is open, the values you enter are written to Obsidian's vault
+scoped local storage. That is the storage Obsidian itself uses for things that
+are disposable, machine local, and not worth syncing:
+
+- It never touches your vault, so nothing shows up in your files or in git.
+- It is per vault, so two vaults never see each other's data.
+- It is per machine, so it is not synced to your other devices.
+
+Only values that can be safely stored and read back are kept: text, numbers,
+booleans and lists of them. Selected files and images are not, because a file
+handle is not something we can restore later.
+
+Saved data is discarded automatically after a week, and we never keep more than
+the 25 most recent forms. You can also turn the whole thing off in
+**Settings → Modal Form → Preserve form data**, which deletes everything kept
+so far.
+
+## When it comes back
+
+### You closed the form by accident
+
+If you close a form with the `X`, by clicking outside of it, or Obsidian goes
+away underneath you, the data is kept. The next time you open the same form it
+comes back, and a notice tells you what was restored and when.
+
+Pressing `Cancel` or `Escape` is treated as a deliberate "I don't want this":
+the saved data is discarded and the next open starts from scratch.
+
+### A template failed
+
+When a template cannot be rendered, or the note cannot be created because
+Templater reported an error, you get a dialog that shows **the actual error**
+and lets you choose what to do:
+
+- **Reopen form** — the form opens again with everything you had typed, so you
+  can fix the offending value and submit again.
+- **Fix the template** — opens the rendered template in an editor so you can
+  correct it by hand and retry. Useful when the problem is in the template
+  itself rather than in your input.
+- **Discard** — closes the dialog. Nothing is lost: the data stays recoverable.
+
+For the "Insert template" flows the text is already in your note by the time
+Templater runs, so there is nothing to retry. You still get a clear error
+explaining that the text was inserted but its Templater commands were not
+executed.
+
+### Anything else
+
+Run the **Modal Forms: Recover form data** command from the command palette. It
+lists the forms we have data for, newest first, with how many fields each one
+has and when it was saved. Picking one reopens that form with the data filled
+in.
+
+This is the escape hatch for the cases the plugin cannot see, such as a
+Templater or QuickAdd script of your own that throws after the form was
+submitted.
+
+## Opting out for a single form
+
+If you open forms from your own scripts and you would rather not have a
+particular one remembered, pass `preserveData: false`:
+
+```js
+const result = await MF.openForm("my-form", { preserveData: false });
+```
+
+Nothing is stored for that open, and any data already saved for that form is
+left untouched. Form previews inside the form editor already do this, so trying
+out a form you are editing never interferes with the real thing.

--- a/docs/data-recovery.md
+++ b/docs/data-recovery.md
@@ -24,6 +24,11 @@ the 25 most recent forms. You can also turn the whole thing off in
 **Settings → Modal Form → Preserve form data**, which deletes everything kept
 so far.
 
+Data is tracked per form *and* per set of fields. A form opened through
+[`limitedForm`](../README.md#call-the-form-from-javascript) with `pick` or
+`omit` is a different shape than the full form, so it gets its own saved data
+and can never truncate or delete what the full form had.
+
 ## When it comes back
 
 ### You closed the form by accident

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Change log: changelog.md
     - Importing a form: import-forms.md
     - Templates: templates.md
+    - Data recovery: data-recovery.md
     - Form builder API: FormBuilder.md
     - Self-contained forms: self-contained-forms.md
     - Blog:

--- a/src/API.ts
+++ b/src/API.ts
@@ -68,7 +68,7 @@ export class API {
      */
     openModalForm(formDefinition: FormDefinition, options?: FormOptions): Promise<FormResult> {
         return new Promise((resolve) => {
-            new FormModal(this.app, formDefinition, resolve, options).open();
+            new FormModal(this.app, formDefinition, resolve, options, this.plugin.drafts).open();
         });
     }
     exampleForm(options?: FormOptions): Promise<FormResult> {

--- a/src/FormModal.ts
+++ b/src/FormModal.ts
@@ -5,7 +5,13 @@ import FormModalComponent from "./FormModal.svelte";
 import FormResult from "./core/FormResult";
 import { formDataFromFormDefaults } from "./core/formDataFromFormDefaults";
 import type { FormDefinition, FormOptions } from "./core/formDefinition";
-import { makeNoopDraftStore, sanitizeDraftData, type FormDraftStore } from "./core/formDrafts";
+import {
+    draftIdFor,
+    makeNoopDraftStore,
+    sanitizeDraftData,
+    type DraftId,
+    type FormDraftStore,
+} from "./core/formDrafts";
 import type { ModalFormData } from "./core/formResultTypes";
 import { FormEngine, makeFormEngine } from "./store/formEngine";
 import { log_notice } from "./utils/Log";
@@ -37,6 +43,7 @@ export class FormModal extends Modal {
     formEngine: FormEngine;
     private hasBeenHandled = false;
     private drafts: FormDraftStore;
+    private draftId: DraftId;
     private persistDraft: Debounced<[]>;
 
     constructor(
@@ -50,9 +57,10 @@ export class FormModal extends Modal {
         // Throwaway opens such as previews must not leave anything behind, nor
         // pick up a draft that belongs to a real use of the same form.
         this.drafts = options?.preserveData === false ? makeNoopDraftStore() : drafts;
+        this.draftId = draftIdFor(modalDefinition);
         // Values passed by the caller always win over a recovered draft:
         // they are an explicit intent, the draft is a leftover.
-        const recovered = this.drafts.recover(modalDefinition.name);
+        const recovered = this.drafts.recover(this.draftId);
         const recoveredValues = pipe(
             recovered,
             O.map((draft) => draft.data),
@@ -72,7 +80,7 @@ export class FormModal extends Modal {
         }
         this.persistDraft = debounce(() => {
             this.drafts.save({
-                formName: this.modalDefinition.name,
+                ...this.draftId,
                 formTitle: this.modalDefinition.title,
                 status: "pending",
                 data: sanitizeDraftData(this.formEngine.getValues()),
@@ -86,7 +94,7 @@ export class FormModal extends Modal {
                 // may still fail, so we keep the draft around instead of
                 // deleting it. It just stops being restored automatically.
                 this.drafts.save({
-                    formName: this.modalDefinition.name,
+                    ...this.draftId,
                     formTitle: this.modalDefinition.title,
                     status: "submitted",
                     data: sanitizeDraftData(result),
@@ -98,7 +106,7 @@ export class FormModal extends Modal {
                 this.hasBeenHandled = true;
                 // Cancelling is an explicit "I don't want this", so the draft goes away
                 this.persistDraft.cancel();
-                this.drafts.clear(this.modalDefinition.name);
+                this.drafts.clear(this.draftId);
                 this.onSubmit(FormResult.make({}, "cancelled"));
                 super.close();
             },

--- a/src/FormModal.ts
+++ b/src/FormModal.ts
@@ -1,46 +1,104 @@
-import { throttle } from "@std";
+import { debounce, O, pipe, throttle, type Debounced } from "@std";
 import { App, Modal, Setting } from "obsidian";
 import { SvelteComponent } from "svelte";
 import FormModalComponent from "./FormModal.svelte";
 import FormResult from "./core/FormResult";
-import type { ModalFormData } from "./core/formResultTypes";
 import { formDataFromFormDefaults } from "./core/formDataFromFormDefaults";
 import type { FormDefinition, FormOptions } from "./core/formDefinition";
+import { makeNoopDraftStore, sanitizeDraftData, type FormDraftStore } from "./core/formDrafts";
+import type { ModalFormData } from "./core/formResultTypes";
 import { FormEngine, makeFormEngine } from "./store/formEngine";
 import { log_notice } from "./utils/Log";
 
 export type SubmitFn = (formResult: FormResult) => void;
 
+/** How long we wait after the last keystroke before writing the draft */
+const DRAFT_SAVE_DELAY_MS = 400;
+
 const notify = throttle(
     (msg: string[]) => log_notice("⚠️  The form has errors ⚠️", msg.join("\n"), "notice-warning"),
     2000,
 );
+
+function describeAge(millis: number): string {
+    const minutes = Math.round(millis / 60000);
+    if (minutes < 1) return "a moment ago";
+    if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+    const days = Math.round(hours / 24);
+    return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
 export class FormModal extends Modal {
     svelteComponents: SvelteComponent[] = [];
     initialFormValues: ModalFormData;
     subscriptions: (() => void)[] = [];
     formEngine: FormEngine;
     private hasBeenHandled = false;
-    
+    private drafts: FormDraftStore;
+    private persistDraft: Debounced<[]>;
+
     constructor(
         app: App,
         private modalDefinition: FormDefinition,
         private onSubmit: SubmitFn,
         options?: FormOptions,
+        drafts: FormDraftStore = makeNoopDraftStore(),
     ) {
         super(app);
-        this.initialFormValues = formDataFromFormDefaults(
-            modalDefinition.fields,
-            options?.values ?? {},
+        // Throwaway opens such as previews must not leave anything behind, nor
+        // pick up a draft that belongs to a real use of the same form.
+        this.drafts = options?.preserveData === false ? makeNoopDraftStore() : drafts;
+        // Values passed by the caller always win over a recovered draft:
+        // they are an explicit intent, the draft is a leftover.
+        const recovered = this.drafts.recover(modalDefinition.name);
+        const recoveredValues = pipe(
+            recovered,
+            O.map((draft) => draft.data),
+            O.getOrElse((): ModalFormData => ({})),
         );
+        this.initialFormValues = formDataFromFormDefaults(modalDefinition.fields, {
+            ...recoveredValues,
+            ...(options?.values ?? {}),
+        });
+        if (O.isSome(recovered)) {
+            log_notice(
+                "↩️ Recovered unsaved form data",
+                `We restored what you had typed in "${modalDefinition.title}" ` +
+                    `${describeAge(Date.now() - recovered.value.savedAt)}. ` +
+                    "Cancel the form if you would rather start from scratch.",
+            );
+        }
+        this.persistDraft = debounce(() => {
+            this.drafts.save({
+                formName: this.modalDefinition.name,
+                formTitle: this.modalDefinition.title,
+                status: "pending",
+                data: sanitizeDraftData(this.formEngine.getValues()),
+            });
+        }, DRAFT_SAVE_DELAY_MS);
         this.formEngine = makeFormEngine({
             onSubmit: (result) => {
                 this.hasBeenHandled = true;
+                this.persistDraft.cancel();
+                // The data made it out of the form, but whatever consumes it
+                // may still fail, so we keep the draft around instead of
+                // deleting it. It just stops being restored automatically.
+                this.drafts.save({
+                    formName: this.modalDefinition.name,
+                    formTitle: this.modalDefinition.title,
+                    status: "submitted",
+                    data: sanitizeDraftData(result),
+                });
                 this.onSubmit(FormResult.make(result, "ok"));
                 super.close();
             },
             onCancel: () => {
                 this.hasBeenHandled = true;
+                // Cancelling is an explicit "I don't want this", so the draft goes away
+                this.persistDraft.cancel();
+                this.drafts.clear(this.modalDefinition.name);
                 this.onSubmit(FormResult.make({}, "cancelled"));
                 super.close();
             },
@@ -48,11 +106,14 @@ export class FormModal extends Modal {
         });
         // this.formEngine.subscribe(console.log);
     }
-    
+
     // Override the close method to handle X button and outside clicks
     close() {
         if (!this.hasBeenHandled) {
             this.hasBeenHandled = true;
+            // Closing without cancelling is the accidental case, so make sure
+            // the very last edit is stored before the modal goes away.
+            this.persistDraft.flush();
             this.onSubmit(FormResult.make({}, "cancelled"));
         }
         super.close();
@@ -74,6 +135,15 @@ export class FormModal extends Modal {
                     app: this.app,
                     reportFormErrors: notify,
                 },
+            }),
+        );
+
+        // Subscribing after the fields have been registered by the component
+        // avoids storing a draft of a form that has no fields yet.
+        this.subscriptions.push(
+            this.formEngine.subscribe(() => {
+                if (this.hasBeenHandled) return;
+                this.persistDraft();
             }),
         );
 
@@ -106,6 +176,7 @@ export class FormModal extends Modal {
 
     onClose() {
         const { contentEl } = this;
+        this.persistDraft.cancel();
         this.svelteComponents.forEach((component) => component.$destroy());
         this.subscriptions.forEach((subscription) => subscription());
         contentEl.empty();

--- a/src/ModalFormSettingTab.ts
+++ b/src/ModalFormSettingTab.ts
@@ -51,5 +51,19 @@ export class ModalFormSettingTab extends PluginSettingTab {
                         await this.plugin.setAttachShortcutToGlobalWindow(value);
                     });
             });
+
+        new Setting(containerEl)
+            .setName("Preserve form data")
+            .setDesc(
+                "Keep what you type in a form while it is open, so it can be recovered if the " +
+                    "form is closed by accident or a template fails after submitting. " +
+                    "The data is stored locally, never in your vault, and is discarded after a week. " +
+                    "Disabling this deletes any data kept so far.",
+            )
+            .addToggle((component) => {
+                component.setValue(settings.preserveFormDrafts).onChange(async (value) => {
+                    await this.plugin.setPreserveFormDrafts(value);
+                });
+            });
     }
 }

--- a/src/core/formDefinition.ts
+++ b/src/core/formDefinition.ts
@@ -82,6 +82,13 @@ export type FormWithTemplate = Simplify<
 
 export type FormOptions = {
     values?: Record<string, unknown>;
+    /**
+     * Whether what the user types should be kept while the form is open, so it
+     * can be recovered if the form is closed by accident or something fails
+     * after submitting. Defaults to true, set it to false for throwaway opens
+     * such as previews.
+     */
+    preserveData?: boolean;
 };
 
 type KeyOfUnion<T> = T extends unknown ? keyof T : never;

--- a/src/core/formDrafts.test.ts
+++ b/src/core/formDrafts.test.ts
@@ -30,7 +30,7 @@ function makeMemoryStorage(initial: unknown = null): DraftStorage & { value: unk
 function draft(overrides: Partial<FormDraft> = {}): FormDraft {
     return {
         formName: "my-form",
-        fieldsKey: draftFieldsKey(["title"]),
+        fieldsKey: draftFieldsKey([{ name: "title" }]),
         formTitle: "My form",
         savedAt: 1000,
         status: "pending",
@@ -41,7 +41,7 @@ function draft(overrides: Partial<FormDraft> = {}): FormDraft {
 
 /** The draft identity of a form with a single "a" field, used by most tests */
 function id(formName: string, fields = ["a"]) {
-    return { formName, fieldsKey: draftFieldsKey(fields) };
+    return { formName, fieldsKey: draftFieldsKey(fields.map((name) => ({ name }))) };
 }
 
 describe("sanitizeDraftData", () => {
@@ -99,7 +99,7 @@ describe("parseDrafts", () => {
             drafts: [
                 {
                     formName: "a",
-                    fieldsKey: draftFieldsKey(["good"]),
+                    fieldsKey: draftFieldsKey([{ name: "good" }]),
                     formTitle: "A",
                     savedAt: 5,
                     status: "submitted",
@@ -110,7 +110,7 @@ describe("parseDrafts", () => {
         expect(parseDrafts(stored)).toEqual([
             {
                 formName: "a",
-                fieldsKey: draftFieldsKey(["good"]),
+                fieldsKey: draftFieldsKey([{ name: "good" }]),
                 formTitle: "A",
                 savedAt: 5,
                 status: "submitted",
@@ -173,6 +173,26 @@ describe("draftIdFor", () => {
         // This is what `limitedForm` produces: same name, fewer fields
         expect(draftIdFor({ name: "f", fields: [{ name: "a" }, { name: "b" }] })).not.toEqual(
             draftIdFor({ name: "f", fields: [{ name: "a" }] }),
+        );
+    });
+
+    it("tells apart a field that kept its name but changed its input type", () => {
+        // A value typed into a text field has no business landing in the
+        // number field that replaced it
+        expect(
+            draftIdFor({ name: "f", fields: [{ name: "a", input: { type: "text" } }] }),
+        ).not.toEqual(
+            draftIdFor({ name: "f", fields: [{ name: "a", input: { type: "number" } }] }),
+        );
+    });
+
+    it("is unchanged when the fields and their types are the same", () => {
+        const fields = [
+            { name: "a", input: { type: "text" } },
+            { name: "b", input: { type: "multiselect" } },
+        ];
+        expect(draftIdFor({ name: "f", fields })).toEqual(
+            draftIdFor({ name: "f", fields: [...fields].reverse() }),
         );
     });
 });

--- a/src/core/formDrafts.test.ts
+++ b/src/core/formDrafts.test.ts
@@ -1,0 +1,249 @@
+import { O } from "@std";
+import {
+    DRAFT_MAX_AGE_MS,
+    MAX_STORED_DRAFTS,
+    draftHasContent,
+    makeFormDraftStore,
+    parseDrafts,
+    pruneDrafts,
+    sanitizeDraftData,
+    type DraftStorage,
+    type FormDraft,
+} from "./formDrafts";
+
+function makeMemoryStorage(initial: unknown = null): DraftStorage & { value: unknown } {
+    return {
+        value: initial,
+        load() {
+            // Simulates a round trip through local storage, so tests catch
+            // anything that survives only because it is the same object.
+            return this.value === null ? null : JSON.parse(JSON.stringify(this.value));
+        },
+        save(value) {
+            this.value = value;
+        },
+    };
+}
+
+function draft(overrides: Partial<FormDraft> = {}): FormDraft {
+    return {
+        formName: "my-form",
+        formTitle: "My form",
+        savedAt: 1000,
+        status: "pending",
+        data: { title: "hello" },
+        ...overrides,
+    };
+}
+
+describe("sanitizeDraftData", () => {
+    it("keeps primitives and arrays of primitives", () => {
+        expect(
+            sanitizeDraftData({
+                text: "a",
+                count: 3,
+                flag: true,
+                tags: ["x", "y"],
+            }),
+        ).toEqual({ text: "a", count: 3, flag: true, tags: ["x", "y"] });
+    });
+
+    it("drops values we cannot store and read back", () => {
+        expect(
+            sanitizeDraftData({
+                good: "a",
+                file: { path: "note.md", basename: "note" },
+                fn: () => "nope",
+                nested: [{ a: 1 }],
+                nothing: undefined,
+            }),
+        ).toEqual({ good: "a" });
+    });
+});
+
+describe("draftHasContent", () => {
+    it.each([
+        [{}, false],
+        [{ a: "" }, false],
+        [{ a: false }, false],
+        [{ a: [] }, false],
+        [{ a: "x" }, true],
+        [{ a: true }, true],
+        [{ a: 0 }, true],
+        [{ a: ["x"] }, true],
+        [{ a: "", b: false, c: ["x"] }, true],
+    ])("%p is %p", (data, expected) => {
+        expect(draftHasContent(data)).toBe(expected);
+    });
+});
+
+describe("parseDrafts", () => {
+    it("returns nothing for absent or malformed storage", () => {
+        expect(parseDrafts(null)).toEqual([]);
+        expect(parseDrafts(undefined)).toEqual([]);
+        expect(parseDrafts("garbage")).toEqual([]);
+        expect(parseDrafts({ drafts: "not an array" })).toEqual([]);
+    });
+
+    it("reads back what was stored, dropping unusable values", () => {
+        const stored = {
+            version: 1,
+            drafts: [
+                {
+                    formName: "a",
+                    formTitle: "A",
+                    savedAt: 5,
+                    status: "submitted",
+                    data: { good: "x", bad: { nope: true } },
+                },
+            ],
+        };
+        expect(parseDrafts(stored)).toEqual([
+            {
+                formName: "a",
+                formTitle: "A",
+                savedAt: 5,
+                status: "submitted",
+                data: { good: "x" },
+            },
+        ]);
+    });
+
+    it("falls back to sensible values for older or partial entries", () => {
+        expect(parseDrafts({ drafts: [{ formName: "a", savedAt: 5 }] })).toEqual([
+            { formName: "a", formTitle: "a", savedAt: 5, status: "pending", data: {} },
+        ]);
+    });
+});
+
+describe("pruneDrafts", () => {
+    it("sorts newest first", () => {
+        const result = pruneDrafts(
+            [draft({ formName: "old", savedAt: 1 }), draft({ formName: "new", savedAt: 2 })],
+            10,
+        );
+        expect(result.map((d) => d.formName)).toEqual(["new", "old"]);
+    });
+
+    it("drops expired drafts", () => {
+        const now = DRAFT_MAX_AGE_MS + 100;
+        const result = pruneDrafts(
+            [
+                draft({ formName: "expired", savedAt: 50 }),
+                draft({ formName: "fresh", savedAt: now }),
+            ],
+            now,
+        );
+        expect(result.map((d) => d.formName)).toEqual(["fresh"]);
+    });
+
+    it("keeps at most MAX_STORED_DRAFTS entries", () => {
+        const drafts = Array.from({ length: MAX_STORED_DRAFTS + 5 }, (_, i) =>
+            draft({ formName: `form-${i}`, savedAt: i }),
+        );
+        expect(pruneDrafts(drafts, MAX_STORED_DRAFTS + 5)).toHaveLength(MAX_STORED_DRAFTS);
+    });
+});
+
+describe("makeFormDraftStore", () => {
+    it("stores and recovers a draft", () => {
+        const storage = makeMemoryStorage();
+        const store = makeFormDraftStore(storage, { now: () => 100 });
+        store.save({
+            formName: "my-form",
+            formTitle: "My form",
+            status: "pending",
+            data: { title: "unfinished business" },
+        });
+        expect(store.recover("my-form")).toEqual(
+            O.some({
+                formName: "my-form",
+                formTitle: "My form",
+                savedAt: 100,
+                status: "pending",
+                data: { title: "unfinished business" },
+            }),
+        );
+    });
+
+    it("does not store an empty draft, and clears a previous one", () => {
+        const storage = makeMemoryStorage();
+        const store = makeFormDraftStore(storage, { now: () => 100 });
+        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "x" } });
+        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "" } });
+        expect(store.list()).toEqual([]);
+        expect(storage.value).toBeNull();
+    });
+
+    it("replaces the draft of the same form instead of piling up", () => {
+        const storage = makeMemoryStorage();
+        let now = 1;
+        const store = makeFormDraftStore(storage, { now: () => now });
+        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "one" } });
+        now = 2;
+        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "two" } });
+        expect(store.list()).toHaveLength(1);
+        expect(store.find("f")).toEqual(O.some(expect.objectContaining({ data: { a: "two" } })));
+    });
+
+    it("does not recover a submitted draft automatically, but can still find it", () => {
+        const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
+        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "x" } });
+        store.markSubmitted("f");
+        expect(store.recover("f")).toEqual(O.none);
+        expect(store.find("f")).toEqual(O.some(expect.objectContaining({ status: "submitted" })));
+    });
+
+    it("recovers a submitted draft again once it is marked pending", () => {
+        const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
+        store.save({ formName: "f", formTitle: "F", status: "submitted", data: { a: "x" } });
+        expect(store.recover("f")).toEqual(O.none);
+        store.markPending("f");
+        expect(store.recover("f")).toEqual(O.some(expect.objectContaining({ data: { a: "x" } })));
+    });
+
+    it("clears a single form without touching the others", () => {
+        const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
+        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        store.save({ formName: "b", formTitle: "B", status: "pending", data: { x: "2" } });
+        store.clear("a");
+        expect(store.list().map((d) => d.formName)).toEqual(["b"]);
+    });
+
+    it("empties the storage when the last draft is gone", () => {
+        const storage = makeMemoryStorage();
+        const store = makeFormDraftStore(storage, { now: () => 1 });
+        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        store.clear("a");
+        expect(storage.value).toBeNull();
+    });
+
+    it("stores nothing while disabled, but keeps previous drafts readable", () => {
+        const storage = makeMemoryStorage();
+        let enabled = true;
+        const store = makeFormDraftStore(storage, { now: () => 1, isEnabled: () => enabled });
+        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        enabled = false;
+        store.save({ formName: "b", formTitle: "B", status: "pending", data: { x: "2" } });
+        expect(store.list().map((d) => d.formName)).toEqual(["a"]);
+        expect(store.recover("a")).toEqual(O.none);
+        expect(store.find("a")).toEqual(O.some(expect.objectContaining({ formName: "a" })));
+    });
+
+    it("drops expired drafts when pruned", () => {
+        const storage = makeMemoryStorage();
+        const store = makeFormDraftStore(storage, { now: () => 1 });
+        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        const later = makeFormDraftStore(storage, { now: () => DRAFT_MAX_AGE_MS + 2 });
+        later.prune();
+        expect(storage.value).toBeNull();
+    });
+
+    it("survives a corrupted storage payload", () => {
+        const storage = makeMemoryStorage("💥");
+        const store = makeFormDraftStore(storage, { now: () => 1 });
+        expect(store.list()).toEqual([]);
+        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        expect(store.recover("a")).toEqual(O.some(expect.objectContaining({ formName: "a" })));
+    });
+});

--- a/src/core/formDrafts.test.ts
+++ b/src/core/formDrafts.test.ts
@@ -2,7 +2,9 @@ import { O } from "@std";
 import {
     DRAFT_MAX_AGE_MS,
     MAX_STORED_DRAFTS,
+    draftFieldsKey,
     draftHasContent,
+    draftIdFor,
     makeFormDraftStore,
     parseDrafts,
     pruneDrafts,
@@ -28,12 +30,18 @@ function makeMemoryStorage(initial: unknown = null): DraftStorage & { value: unk
 function draft(overrides: Partial<FormDraft> = {}): FormDraft {
     return {
         formName: "my-form",
+        fieldsKey: draftFieldsKey(["title"]),
         formTitle: "My form",
         savedAt: 1000,
         status: "pending",
         data: { title: "hello" },
         ...overrides,
     };
+}
+
+/** The draft identity of a form with a single "a" field, used by most tests */
+function id(formName: string, fields = ["a"]) {
+    return { formName, fieldsKey: draftFieldsKey(fields) };
 }
 
 describe("sanitizeDraftData", () => {
@@ -91,6 +99,7 @@ describe("parseDrafts", () => {
             drafts: [
                 {
                     formName: "a",
+                    fieldsKey: draftFieldsKey(["good"]),
                     formTitle: "A",
                     savedAt: 5,
                     status: "submitted",
@@ -101,6 +110,7 @@ describe("parseDrafts", () => {
         expect(parseDrafts(stored)).toEqual([
             {
                 formName: "a",
+                fieldsKey: draftFieldsKey(["good"]),
                 formTitle: "A",
                 savedAt: 5,
                 status: "submitted",
@@ -111,7 +121,14 @@ describe("parseDrafts", () => {
 
     it("falls back to sensible values for older or partial entries", () => {
         expect(parseDrafts({ drafts: [{ formName: "a", savedAt: 5 }] })).toEqual([
-            { formName: "a", formTitle: "a", savedAt: 5, status: "pending", data: {} },
+            {
+                formName: "a",
+                fieldsKey: "",
+                formTitle: "a",
+                savedAt: 5,
+                status: "pending",
+                data: {},
+            },
         ]);
     });
 });
@@ -145,19 +162,34 @@ describe("pruneDrafts", () => {
     });
 });
 
+describe("draftIdFor", () => {
+    it("gives the same identity regardless of the order of the fields", () => {
+        expect(draftIdFor({ name: "f", fields: [{ name: "b" }, { name: "a" }] })).toEqual(
+            draftIdFor({ name: "f", fields: [{ name: "a" }, { name: "b" }] }),
+        );
+    });
+
+    it("tells apart forms that share a name but not their fields", () => {
+        // This is what `limitedForm` produces: same name, fewer fields
+        expect(draftIdFor({ name: "f", fields: [{ name: "a" }, { name: "b" }] })).not.toEqual(
+            draftIdFor({ name: "f", fields: [{ name: "a" }] }),
+        );
+    });
+});
+
 describe("makeFormDraftStore", () => {
     it("stores and recovers a draft", () => {
         const storage = makeMemoryStorage();
         const store = makeFormDraftStore(storage, { now: () => 100 });
         store.save({
-            formName: "my-form",
+            ...id("my-form", ["title"]),
             formTitle: "My form",
             status: "pending",
             data: { title: "unfinished business" },
         });
-        expect(store.recover("my-form")).toEqual(
+        expect(store.recover(id("my-form", ["title"]))).toEqual(
             O.some({
-                formName: "my-form",
+                ...id("my-form", ["title"]),
                 formTitle: "My form",
                 savedAt: 100,
                 status: "pending",
@@ -169,8 +201,8 @@ describe("makeFormDraftStore", () => {
     it("does not store an empty draft, and clears a previous one", () => {
         const storage = makeMemoryStorage();
         const store = makeFormDraftStore(storage, { now: () => 100 });
-        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "x" } });
-        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "" } });
+        store.save({ ...id("f"), formTitle: "F", status: "pending", data: { a: "x" } });
+        store.save({ ...id("f"), formTitle: "F", status: "pending", data: { a: "" } });
         expect(store.list()).toEqual([]);
         expect(storage.value).toBeNull();
     });
@@ -179,42 +211,48 @@ describe("makeFormDraftStore", () => {
         const storage = makeMemoryStorage();
         let now = 1;
         const store = makeFormDraftStore(storage, { now: () => now });
-        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "one" } });
+        store.save({ ...id("f"), formTitle: "F", status: "pending", data: { a: "one" } });
         now = 2;
-        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "two" } });
+        store.save({ ...id("f"), formTitle: "F", status: "pending", data: { a: "two" } });
         expect(store.list()).toHaveLength(1);
-        expect(store.find("f")).toEqual(O.some(expect.objectContaining({ data: { a: "two" } })));
+        expect(store.find(id("f"))).toEqual(
+            O.some(expect.objectContaining({ data: { a: "two" } })),
+        );
     });
 
     it("does not recover a submitted draft automatically, but can still find it", () => {
         const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
-        store.save({ formName: "f", formTitle: "F", status: "pending", data: { a: "x" } });
-        store.markSubmitted("f");
-        expect(store.recover("f")).toEqual(O.none);
-        expect(store.find("f")).toEqual(O.some(expect.objectContaining({ status: "submitted" })));
+        store.save({ ...id("f"), formTitle: "F", status: "pending", data: { a: "x" } });
+        store.markSubmitted(id("f"));
+        expect(store.recover(id("f"))).toEqual(O.none);
+        expect(store.find(id("f"))).toEqual(
+            O.some(expect.objectContaining({ status: "submitted" })),
+        );
     });
 
     it("recovers a submitted draft again once it is marked pending", () => {
         const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
-        store.save({ formName: "f", formTitle: "F", status: "submitted", data: { a: "x" } });
-        expect(store.recover("f")).toEqual(O.none);
-        store.markPending("f");
-        expect(store.recover("f")).toEqual(O.some(expect.objectContaining({ data: { a: "x" } })));
+        store.save({ ...id("f"), formTitle: "F", status: "submitted", data: { a: "x" } });
+        expect(store.recover(id("f"))).toEqual(O.none);
+        store.markPending(id("f"));
+        expect(store.recover(id("f"))).toEqual(
+            O.some(expect.objectContaining({ data: { a: "x" } })),
+        );
     });
 
     it("clears a single form without touching the others", () => {
         const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
-        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
-        store.save({ formName: "b", formTitle: "B", status: "pending", data: { x: "2" } });
-        store.clear("a");
+        store.save({ ...id("a"), formTitle: "A", status: "pending", data: { a: "1" } });
+        store.save({ ...id("b"), formTitle: "B", status: "pending", data: { a: "2" } });
+        store.clear(id("a"));
         expect(store.list().map((d) => d.formName)).toEqual(["b"]);
     });
 
     it("empties the storage when the last draft is gone", () => {
         const storage = makeMemoryStorage();
         const store = makeFormDraftStore(storage, { now: () => 1 });
-        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
-        store.clear("a");
+        store.save({ ...id("a"), formTitle: "A", status: "pending", data: { a: "1" } });
+        store.clear(id("a"));
         expect(storage.value).toBeNull();
     });
 
@@ -222,18 +260,18 @@ describe("makeFormDraftStore", () => {
         const storage = makeMemoryStorage();
         let enabled = true;
         const store = makeFormDraftStore(storage, { now: () => 1, isEnabled: () => enabled });
-        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        store.save({ ...id("a"), formTitle: "A", status: "pending", data: { a: "1" } });
         enabled = false;
-        store.save({ formName: "b", formTitle: "B", status: "pending", data: { x: "2" } });
+        store.save({ ...id("b"), formTitle: "B", status: "pending", data: { a: "2" } });
         expect(store.list().map((d) => d.formName)).toEqual(["a"]);
-        expect(store.recover("a")).toEqual(O.none);
-        expect(store.find("a")).toEqual(O.some(expect.objectContaining({ formName: "a" })));
+        expect(store.recover(id("a"))).toEqual(O.none);
+        expect(store.find(id("a"))).toEqual(O.some(expect.objectContaining({ formName: "a" })));
     });
 
     it("drops expired drafts when pruned", () => {
         const storage = makeMemoryStorage();
         const store = makeFormDraftStore(storage, { now: () => 1 });
-        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
+        store.save({ ...id("a"), formTitle: "A", status: "pending", data: { a: "1" } });
         const later = makeFormDraftStore(storage, { now: () => DRAFT_MAX_AGE_MS + 2 });
         later.prune();
         expect(storage.value).toBeNull();
@@ -243,7 +281,57 @@ describe("makeFormDraftStore", () => {
         const storage = makeMemoryStorage("💥");
         const store = makeFormDraftStore(storage, { now: () => 1 });
         expect(store.list()).toEqual([]);
-        store.save({ formName: "a", formTitle: "A", status: "pending", data: { x: "1" } });
-        expect(store.recover("a")).toEqual(O.some(expect.objectContaining({ formName: "a" })));
+        store.save({ ...id("a"), formTitle: "A", status: "pending", data: { a: "1" } });
+        expect(store.recover(id("a"))).toEqual(O.some(expect.objectContaining({ formName: "a" })));
+    });
+
+    describe("a limited form does not clobber the form it was derived from", () => {
+        const full = draftIdFor({
+            name: "book",
+            fields: [{ name: "title" }, { name: "author" }, { name: "notes" }],
+        });
+        const limited = draftIdFor({ name: "book", fields: [{ name: "title" }] });
+
+        function storeWithFullDraft() {
+            const store = makeFormDraftStore(makeMemoryStorage(), { now: () => 1 });
+            store.save({
+                ...full,
+                formTitle: "Book",
+                status: "pending",
+                data: { title: "Dune", author: "Herbert", notes: "sand" },
+            });
+            return store;
+        }
+
+        it("does not restore the full draft into the limited form", () => {
+            expect(storeWithFullDraft().recover(limited)).toEqual(O.none);
+        });
+
+        it("saving the limited form leaves the full draft untouched", () => {
+            const store = storeWithFullDraft();
+            store.save({
+                ...limited,
+                formTitle: "Book",
+                status: "pending",
+                data: { title: "Messiah" },
+            });
+            expect(store.recover(full)).toEqual(
+                O.some(
+                    expect.objectContaining({
+                        data: { title: "Dune", author: "Herbert", notes: "sand" },
+                    }),
+                ),
+            );
+        });
+
+        it("cancelling the limited form does not delete the full draft", () => {
+            const store = storeWithFullDraft();
+            store.clear(limited);
+            expect(store.recover(full)).toEqual(
+                O.some(
+                    expect.objectContaining({ data: expect.objectContaining({ notes: "sand" }) }),
+                ),
+            );
+        });
     });
 });

--- a/src/core/formDrafts.ts
+++ b/src/core/formDrafts.ts
@@ -1,0 +1,249 @@
+import { E, O, parse, pipe } from "@std";
+import {
+    array,
+    literal,
+    number,
+    object,
+    optional,
+    string,
+    union,
+    unknown,
+    type Output,
+} from "valibot";
+import { isPrimitive, isPrimitiveArray, type ModalFormData } from "./formResultTypes";
+
+/**
+ * Key used to store the drafts in Obsidian's vault scoped local storage.
+ * Obsidian namespaces it per vault, so different vaults never share drafts.
+ */
+export const DRAFTS_STORAGE_KEY = "form-drafts";
+/** Drafts older than this are dropped the next time the store is pruned */
+export const DRAFT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+/** Upper bound of drafts we keep around, so local storage never grows unbounded */
+export const MAX_STORED_DRAFTS = 25;
+
+const DraftStatusSchema = union([literal("pending"), literal("submitted")]);
+/**
+ * `pending` means the data never made it out of the form, so it is safe to
+ * offer it back automatically the next time the form is opened.
+ * `submitted` means the form was submitted, but we keep the data around for a
+ * while because whatever consumed it (a template, a templater command, a user
+ * script) may still fail after the modal is gone.
+ */
+export type DraftStatus = Output<typeof DraftStatusSchema>;
+
+const FormDraftSchema = object({
+    formName: string(),
+    formTitle: optional(string(), ""),
+    savedAt: number(),
+    status: optional(DraftStatusSchema, "pending"),
+    // Validated by `sanitizeDraftData` instead, so a single corrupted value
+    // does not throw away the whole draft.
+    data: optional(unknown(), {}),
+});
+
+const DraftsEnvelopeSchema = object({
+    version: optional(number(), 1),
+    drafts: optional(array(FormDraftSchema), []),
+});
+
+export interface FormDraft {
+    formName: string;
+    formTitle: string;
+    savedAt: number;
+    status: DraftStatus;
+    data: ModalFormData;
+}
+
+export type NewFormDraft = Omit<FormDraft, "savedAt">;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Keeps only the values we know how to serialize and read back.
+ * Anything else (a FileProxy, a nested object, a function) is dropped rather
+ * than making the whole draft unusable.
+ */
+export function sanitizeDraftData(values: Record<string, unknown>): ModalFormData {
+    const result: ModalFormData = {};
+    for (const [key, value] of Object.entries(values)) {
+        if (isPrimitiveArray(value) || isPrimitive(value)) {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
+/**
+ * Tells apart a draft worth recovering from the empty shell a form produces
+ * just by being opened (toggles default to `false`, everything else is absent).
+ */
+export function draftHasContent(data: ModalFormData): boolean {
+    return Object.values(data).some((value) => {
+        if (typeof value === "string") return value.length > 0;
+        if (typeof value === "boolean") return value;
+        if (Array.isArray(value)) return value.length > 0;
+        return true;
+    });
+}
+
+/** Reads whatever local storage returned, discarding anything malformed */
+export function parseDrafts(raw: unknown): FormDraft[] {
+    if (raw === null || raw === undefined) return [];
+    return pipe(
+        parse(DraftsEnvelopeSchema, raw),
+        E.map(({ drafts }) =>
+            drafts.map(
+                (draft): FormDraft => ({
+                    formName: draft.formName,
+                    formTitle: draft.formTitle || draft.formName,
+                    savedAt: draft.savedAt,
+                    status: draft.status,
+                    data: sanitizeDraftData(isRecord(draft.data) ? draft.data : {}),
+                }),
+            ),
+        ),
+        E.getOrElseW((): FormDraft[] => []),
+    );
+}
+
+/** Newest first, expired and excess drafts removed */
+export function pruneDrafts(
+    drafts: FormDraft[],
+    now: number,
+    maxAge = DRAFT_MAX_AGE_MS,
+    maxEntries = MAX_STORED_DRAFTS,
+): FormDraft[] {
+    return [...drafts]
+        .sort((a, b) => b.savedAt - a.savedAt)
+        .filter((draft) => now - draft.savedAt <= maxAge)
+        .slice(0, maxEntries);
+}
+
+export function upsertDraft(drafts: FormDraft[], draft: FormDraft): FormDraft[] {
+    return [draft, ...drafts.filter((d) => d.formName !== draft.formName)];
+}
+
+export function findDraft(drafts: FormDraft[], formName: string): O.Option<FormDraft> {
+    return O.fromNullable(drafts.find((draft) => draft.formName === formName));
+}
+
+/**
+ * The bit of the outside world the draft store needs.
+ * Implemented on top of Obsidian's vault scoped local storage, but kept as an
+ * interface so it can be exercised in tests without an Obsidian app.
+ */
+export interface DraftStorage {
+    load(): unknown;
+    save(value: unknown | null): void;
+}
+
+export interface FormDraftStore {
+    /** Stores (or replaces) the draft of a form */
+    save(draft: NewFormDraft): void;
+    /** The draft of a form, only if it is worth restoring automatically */
+    recover(formName: string): O.Option<FormDraft>;
+    /** The draft of a form, whatever its status */
+    find(formName: string): O.Option<FormDraft>;
+    /** All stored drafts, newest first */
+    list(): FormDraft[];
+    /** Flags the draft as submitted, so it is no longer restored automatically */
+    markSubmitted(formName: string): void;
+    /** Flags the draft as pending again, so the next open of the form restores it */
+    markPending(formName: string): void;
+    clear(formName: string): void;
+    clearAll(): void;
+    /** Drops expired and excess drafts */
+    prune(): void;
+}
+
+type MakeFormDraftStoreOptions = {
+    now?: () => number;
+    /** When drafts are disabled nothing new is stored, but stored drafts stay recoverable */
+    isEnabled?: () => boolean;
+};
+
+export function makeFormDraftStore(
+    storage: DraftStorage,
+    { now = () => Date.now(), isEnabled = () => true }: MakeFormDraftStoreOptions = {},
+): FormDraftStore {
+    function read(): FormDraft[] {
+        return parseDrafts(storage.load());
+    }
+    function write(drafts: FormDraft[]): void {
+        const pruned = pruneDrafts(drafts, now());
+        if (pruned.length === 0) {
+            storage.save(null);
+            return;
+        }
+        storage.save({ version: 1, drafts: pruned });
+    }
+    function setStatus(formName: string, status: DraftStatus): void {
+        const drafts = read();
+        if (!drafts.some((draft) => draft.formName === formName)) return;
+        write(drafts.map((draft) => (draft.formName === formName ? { ...draft, status } : draft)));
+    }
+    function clear(formName: string): void {
+        const drafts = read();
+        if (!drafts.some((draft) => draft.formName === formName)) return;
+        write(drafts.filter((draft) => draft.formName !== formName));
+    }
+    return {
+        save(draft) {
+            if (!isEnabled()) return;
+            const data = sanitizeDraftData(draft.data);
+            if (!draftHasContent(data)) {
+                // An empty draft is noise, and it would shadow a previous
+                // useful one for the same form.
+                clear(draft.formName);
+                return;
+            }
+            write(upsertDraft(read(), { ...draft, data, savedAt: now() }));
+        },
+        recover(formName) {
+            if (!isEnabled()) return O.none;
+            return pipe(
+                findDraft(read(), formName),
+                O.filter((draft) => draft.status === "pending" && draftHasContent(draft.data)),
+            );
+        },
+        find(formName) {
+            return findDraft(read(), formName);
+        },
+        list() {
+            return pruneDrafts(read(), now());
+        },
+        markSubmitted(formName) {
+            setStatus(formName, "submitted");
+        },
+        markPending(formName) {
+            setStatus(formName, "pending");
+        },
+        clear,
+        clearAll() {
+            storage.save(null);
+        },
+        prune() {
+            const drafts = read();
+            if (drafts.length === 0) return;
+            write(drafts);
+        },
+    };
+}
+
+/** A draft store that does nothing, useful as a default and in tests */
+export function makeNoopDraftStore(): FormDraftStore {
+    return {
+        save() {},
+        recover: () => O.none,
+        find: () => O.none,
+        list: () => [],
+        markSubmitted() {},
+        markPending() {},
+        clear() {},
+        clearAll() {},
+        prune() {},
+    };
+}

--- a/src/core/formDrafts.ts
+++ b/src/core/formDrafts.ts
@@ -34,6 +34,7 @@ export type DraftStatus = Output<typeof DraftStatusSchema>;
 
 const FormDraftSchema = object({
     formName: string(),
+    fieldsKey: optional(string(), ""),
     formTitle: optional(string(), ""),
     savedAt: number(),
     status: optional(DraftStatusSchema, "pending"),
@@ -47,8 +48,21 @@ const DraftsEnvelopeSchema = object({
     drafts: optional(array(FormDraftSchema), []),
 });
 
-export interface FormDraft {
+/**
+ * What identifies a draft.
+ *
+ * A form name alone is not enough: `limitedForm` hands out definitions that
+ * keep the name of the original form but only carry some of its fields. If
+ * both shared a draft, filling the limited variant would quietly truncate what
+ * was saved for the full one, and cancelling it would delete the lot.
+ */
+export interface DraftId {
     formName: string;
+    /** Identifies which fields the form that owns the draft actually has */
+    fieldsKey: string;
+}
+
+export interface FormDraft extends DraftId {
     formTitle: string;
     savedAt: number;
     status: DraftStatus;
@@ -56,6 +70,22 @@ export interface FormDraft {
 }
 
 export type NewFormDraft = Omit<FormDraft, "savedAt">;
+
+/** Stable regardless of the order the fields come in */
+export function draftFieldsKey(fieldNames: readonly string[]): string {
+    return JSON.stringify([...fieldNames].sort());
+}
+
+export function draftIdFor(form: { name: string; fields: readonly { name: string }[] }): DraftId {
+    return {
+        formName: form.name,
+        fieldsKey: draftFieldsKey(form.fields.map((field) => field.name)),
+    };
+}
+
+function isSameDraft(a: DraftId, b: DraftId): boolean {
+    return a.formName === b.formName && a.fieldsKey === b.fieldsKey;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -98,6 +128,7 @@ export function parseDrafts(raw: unknown): FormDraft[] {
             drafts.map(
                 (draft): FormDraft => ({
                     formName: draft.formName,
+                    fieldsKey: draft.fieldsKey,
                     formTitle: draft.formTitle || draft.formName,
                     savedAt: draft.savedAt,
                     status: draft.status,
@@ -123,11 +154,11 @@ export function pruneDrafts(
 }
 
 export function upsertDraft(drafts: FormDraft[], draft: FormDraft): FormDraft[] {
-    return [draft, ...drafts.filter((d) => d.formName !== draft.formName)];
+    return [draft, ...drafts.filter((d) => !isSameDraft(d, draft))];
 }
 
-export function findDraft(drafts: FormDraft[], formName: string): O.Option<FormDraft> {
-    return O.fromNullable(drafts.find((draft) => draft.formName === formName));
+export function findDraft(drafts: FormDraft[], id: DraftId): O.Option<FormDraft> {
+    return O.fromNullable(drafts.find((draft) => isSameDraft(draft, id)));
 }
 
 /**
@@ -144,16 +175,16 @@ export interface FormDraftStore {
     /** Stores (or replaces) the draft of a form */
     save(draft: NewFormDraft): void;
     /** The draft of a form, only if it is worth restoring automatically */
-    recover(formName: string): O.Option<FormDraft>;
+    recover(id: DraftId): O.Option<FormDraft>;
     /** The draft of a form, whatever its status */
-    find(formName: string): O.Option<FormDraft>;
+    find(id: DraftId): O.Option<FormDraft>;
     /** All stored drafts, newest first */
     list(): FormDraft[];
     /** Flags the draft as submitted, so it is no longer restored automatically */
-    markSubmitted(formName: string): void;
+    markSubmitted(id: DraftId): void;
     /** Flags the draft as pending again, so the next open of the form restores it */
-    markPending(formName: string): void;
-    clear(formName: string): void;
+    markPending(id: DraftId): void;
+    clear(id: DraftId): void;
     clearAll(): void;
     /** Drops expired and excess drafts */
     prune(): void;
@@ -180,15 +211,15 @@ export function makeFormDraftStore(
         }
         storage.save({ version: 1, drafts: pruned });
     }
-    function setStatus(formName: string, status: DraftStatus): void {
+    function setStatus(id: DraftId, status: DraftStatus): void {
         const drafts = read();
-        if (!drafts.some((draft) => draft.formName === formName)) return;
-        write(drafts.map((draft) => (draft.formName === formName ? { ...draft, status } : draft)));
+        if (!drafts.some((draft) => isSameDraft(draft, id))) return;
+        write(drafts.map((draft) => (isSameDraft(draft, id) ? { ...draft, status } : draft)));
     }
-    function clear(formName: string): void {
+    function clear(id: DraftId): void {
         const drafts = read();
-        if (!drafts.some((draft) => draft.formName === formName)) return;
-        write(drafts.filter((draft) => draft.formName !== formName));
+        if (!drafts.some((draft) => isSameDraft(draft, id))) return;
+        write(drafts.filter((draft) => !isSameDraft(draft, id)));
     }
     return {
         save(draft) {
@@ -197,29 +228,29 @@ export function makeFormDraftStore(
             if (!draftHasContent(data)) {
                 // An empty draft is noise, and it would shadow a previous
                 // useful one for the same form.
-                clear(draft.formName);
+                clear(draft);
                 return;
             }
             write(upsertDraft(read(), { ...draft, data, savedAt: now() }));
         },
-        recover(formName) {
+        recover(id) {
             if (!isEnabled()) return O.none;
             return pipe(
-                findDraft(read(), formName),
+                findDraft(read(), id),
                 O.filter((draft) => draft.status === "pending" && draftHasContent(draft.data)),
             );
         },
-        find(formName) {
-            return findDraft(read(), formName);
+        find(id) {
+            return findDraft(read(), id);
         },
         list() {
             return pruneDrafts(read(), now());
         },
-        markSubmitted(formName) {
-            setStatus(formName, "submitted");
+        markSubmitted(id) {
+            setStatus(id, "submitted");
         },
-        markPending(formName) {
-            setStatus(formName, "pending");
+        markPending(id) {
+            setStatus(id, "pending");
         },
         clear,
         clearAll() {

--- a/src/core/formDrafts.ts
+++ b/src/core/formDrafts.ts
@@ -51,14 +51,21 @@ const DraftsEnvelopeSchema = object({
 /**
  * What identifies a draft.
  *
- * A form name alone is not enough: `limitedForm` hands out definitions that
- * keep the name of the original form but only carry some of its fields. If
- * both shared a draft, filling the limited variant would quietly truncate what
- * was saved for the full one, and cancelling it would delete the lot.
+ * A form name alone is not enough, for two reasons:
+ *
+ * - `limitedForm` hands out definitions that keep the name of the original
+ *   form but only carry some of its fields. If both shared a draft, filling
+ *   the limited variant would quietly truncate what was saved for the full
+ *   one, and cancelling it would delete the lot.
+ * - A field can keep its name and change its input type. Values saved under
+ *   the old type do not necessarily fit the new one, and restoring them would
+ *   put the form in a state the user never typed.
+ *
+ * So the identity covers the shape of the form, not just its name.
  */
 export interface DraftId {
     formName: string;
-    /** Identifies which fields the form that owns the draft actually has */
+    /** Identifies the fields the form that owns the draft has, and their types */
     fieldsKey: string;
 }
 
@@ -71,16 +78,15 @@ export interface FormDraft extends DraftId {
 
 export type NewFormDraft = Omit<FormDraft, "savedAt">;
 
+export type DraftFieldShape = { name: string; input?: { type?: string } };
+
 /** Stable regardless of the order the fields come in */
-export function draftFieldsKey(fieldNames: readonly string[]): string {
-    return JSON.stringify([...fieldNames].sort());
+export function draftFieldsKey(fields: readonly DraftFieldShape[]): string {
+    return JSON.stringify(fields.map((field) => `${field.name}:${field.input?.type ?? ""}`).sort());
 }
 
-export function draftIdFor(form: { name: string; fields: readonly { name: string }[] }): DraftId {
-    return {
-        formName: form.name,
-        fieldsKey: draftFieldsKey(form.fields.map((field) => field.name)),
-    };
+export function draftIdFor(form: { name: string; fields: readonly DraftFieldShape[] }): DraftId {
+    return { formName: form.name, fieldsKey: draftFieldsKey(form.fields) };
 }
 
 function isSameDraft(a: DraftId, b: DraftId): boolean {

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -26,6 +26,7 @@ const ModalFormSettingsSchema = object({
     editorPosition: optional(OpenPositionSchema, 'right'),
     attachShortcutToGlobalWindow: optional(boolean(), false),
     globalNamespace: optional(enumType(['MF', 'ModalForm']), 'MF'),
+    preserveFormDrafts: optional(boolean(), true),
     formDefinitions: array(unknown()),
 });
 
@@ -36,6 +37,7 @@ export function getDefaultSettings(): ModalFormSettings {
         editorPosition: 'right',
         attachShortcutToGlobalWindow: false,
         globalNamespace: 'MF',
+        preserveFormDrafts: true,
         formDefinitions: [],
     };
 }
@@ -63,4 +65,10 @@ export interface ModalFormSettings {
     attachShortcutToGlobalWindow: boolean;
     formDefinitions: (MigrationError | FormDefinition)[];
     globalNamespace: 'MF' | 'ModalForm';
+    /**
+     * When enabled, what the user types is kept in Obsidian's vault scoped
+     * local storage while the form is open, so it can be recovered if the form
+     * is closed by accident or something downstream fails.
+     */
+    preserveFormDrafts: boolean;
 }

--- a/src/core/template/renderTemplate.test.ts
+++ b/src/core/template/renderTemplate.test.ts
@@ -1,0 +1,69 @@
+import { E } from "@std";
+import { TemplateError } from "./TemplateError";
+import { describeTemplateError, renderTemplate } from "./renderTemplate";
+import { parseTemplate } from "./templateParser";
+
+function parse(template: string) {
+    const parsed = parseTemplate(template);
+    if (E.isLeft(parsed)) throw new Error(`Bad test template: ${parsed.left}`);
+    return parsed.right;
+}
+
+describe("renderTemplate", () => {
+    it("renders a template like executeTemplate does", () => {
+        expect(renderTemplate(parse("Hello {{name}}"), { name: "world" })).toEqual(
+            E.right("Hello world"),
+        );
+    });
+
+    it("turns a rendering blow up into a TemplateError instead of losing the data", () => {
+        const exploding = [
+            {
+                _tag: "variable" as const,
+                value: "name",
+                transformation: "upper" as const,
+            },
+        ];
+        const data = {
+            get name(): string {
+                throw new Error("kaboom");
+            },
+        };
+        const result = renderTemplate(exploding, data);
+        expect(E.isLeft(result)).toBe(true);
+        if (E.isLeft(result)) {
+            expect(result.left).toBeInstanceOf(TemplateError);
+            expect(describeTemplateError(result.left)).toContain("kaboom");
+        }
+    });
+});
+
+describe("describeTemplateError", () => {
+    it("unwraps the cause so the user sees what actually failed", () => {
+        const error = TemplateError.of("Error creating note from template")(
+            new Error("Templater parsing error: Unexpected token"),
+        );
+        expect(describeTemplateError(error)).toBe(
+            "Error creating note from template: Templater parsing error: Unexpected token",
+        );
+    });
+
+    it("does not repeat the same message twice", () => {
+        const original = new Error("boom");
+        expect(describeTemplateError(TemplateError.of("boom")(original))).toBe("boom");
+    });
+
+    it("handles plain errors, strings and unknown values", () => {
+        expect(describeTemplateError(new Error("plain"))).toBe("plain");
+        expect(describeTemplateError("just a string")).toBe("just a string");
+        expect(describeTemplateError(42)).toBe("42");
+        expect(describeTemplateError(undefined)).toBe("Unknown error");
+        expect(describeTemplateError({})).toBe("Unknown error");
+    });
+
+    it("does not loop forever on a self referencing cause", () => {
+        const error: Error & { cause?: unknown } = new Error("outer");
+        error.cause = error;
+        expect(describeTemplateError(error)).toBe("outer");
+    });
+});

--- a/src/core/template/renderTemplate.ts
+++ b/src/core/template/renderTemplate.ts
@@ -1,0 +1,49 @@
+import { E } from "@std";
+import type { ModalFormData } from "../formResultTypes";
+import { TemplateError } from "./TemplateError";
+import { executeTemplate, type ParsedTemplate } from "./templateParser";
+
+/**
+ * Same as `executeTemplate`, but a broken template produces a `TemplateError`
+ * instead of blowing up the whole flow and taking the user data with it.
+ */
+export function renderTemplate(
+    parsedTemplate: ParsedTemplate,
+    formData: ModalFormData,
+): E.Either<TemplateError, string> {
+    return E.tryCatch(
+        () => executeTemplate(parsedTemplate, formData),
+        TemplateError.of("The form template could not be rendered"),
+    );
+}
+
+/**
+ * Turns whatever a template service threw at us into something a user can act
+ * on. Template failures are usually wrapped errors, and the useful part (the
+ * Templater parse error, the file system error) lives in the cause.
+ */
+export function describeTemplateError(error: unknown): string {
+    const seen = new Set<unknown>();
+    const messages: string[] = [];
+    let current: unknown = error;
+    while (current !== undefined && current !== null && !seen.has(current)) {
+        seen.add(current);
+        if (current instanceof Error) {
+            if (current.message && !messages.includes(current.message)) {
+                messages.push(current.message);
+            }
+            // `cause` is ES2022, which is newer than the lib we target
+            current = (current as Error & { cause?: unknown }).cause;
+        } else if (typeof current === "string") {
+            if (current && !messages.includes(current)) messages.push(current);
+            current = undefined;
+        } else {
+            const asString = String(current);
+            if (asString !== "[object Object]" && !messages.includes(asString)) {
+                messages.push(asString);
+            }
+            current = undefined;
+        }
+    }
+    return messages.length > 0 ? messages.join(": ") : "Unknown error";
+}

--- a/src/core/template/retryForm.ts
+++ b/src/core/template/retryForm.ts
@@ -1,7 +1,7 @@
 import { FormDefinition } from "../formDefinition";
 
 export const retryForm: FormDefinition = {
-    title: "Templater error",
+    title: "Fix the template",
     name: "retry-temlate",
     version: "1",
     fields: [
@@ -11,7 +11,7 @@ export const retryForm: FormDefinition = {
             description: "",
             input: {
                 type: "markdown_block",
-                body: "return `\n==Templater reported an error==\nWe are not sure about what it is, but is very likely a parse error.\nPlease try to fix the templater code below and submit it to retry\n`",
+                body: "return `\n==The template could not be processed==\n\n${form.title ?? ''}\n\nFix the template below and submit it to try again.\n`",
             },
             isRequired: false,
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,12 @@
-import { A, E, O, pipe, TE } from "@std";
-import { MarkdownView, Platform, Plugin, WorkspaceLeaf } from "obsidian";
+import { A, E, O, pipe } from "@std";
+import {
+    Editor,
+    MarkdownFileInfo,
+    MarkdownView,
+    Platform,
+    Plugin,
+    WorkspaceLeaf,
+} from "obsidian";
 import { API } from "src/API";
 import { ModalFormSettingTab } from "src/ModalFormSettingTab";
 import { FormWithTemplate, type FormDefinition } from "src/core/formDefinition";
@@ -19,19 +26,30 @@ import {
     migrateToLatest,
     MigrationError,
 } from "./core/formDefinitionSchema";
+import {
+    DRAFTS_STORAGE_KEY,
+    makeFormDraftStore,
+    makeNoopDraftStore,
+    type FormDraft,
+    type FormDraftStore,
+} from "./core/formDrafts";
+import type { ModalFormData } from "./core/formResultTypes";
 import { TemplateService } from "./core/template/TemplateService";
 import { getTemplateService } from "./core/template/getTemplateService";
+import { describeTemplateError, renderTemplate } from "./core/template/renderTemplate";
 import { retryForm } from "./core/template/retryForm";
-import { executeTemplate } from "./core/template/templateParser";
 import { settingsStore } from "./store/SettngsStore";
+import { DraftPickerModal } from "./suggesters/DraftPickerModal";
 import { FormPickerModal } from "./suggesters/FormPickerModal";
 import { NewNoteModal } from "./suggesters/NewNoteModal";
-import { log_error, log_notice, notifyWarning } from "./utils/Log";
+import { appLocalStorage } from "./utils/appLocalStorage";
+import { log_error, log_notice, notifyError, notifyWarning } from "./utils/Log";
 import { logger } from "./utils/Logger";
 import { file_exists } from "./utils/files";
 import { FormImportModal } from "./views/FormImportView";
 import { TemplateBuilderModal } from "./views/TemplateBuilderModal";
 import { TEMPLATE_BUILDER_VIEW, TemplateBuilderView } from "./views/TemplateBuilderView";
+import { askTemplateFailure } from "./views/TemplateFailureModal";
 import { makeModel } from "./views/components/TemplateBuilder";
 
 type ViewType = typeof EDIT_FORM_VIEW | typeof MANAGE_FORMS_VIEW | typeof TEMPLATE_BUILDER_VIEW;
@@ -63,6 +81,11 @@ export default class ModalFormPlugin extends Plugin {
     private unsubscribeSettingsStore: () => void = () => {};
     // This things will be setup in the onload function rather than constructor
     public api!: API;
+    /**
+     * Keeps what the user typed while a form is open, so a crash, an accidental
+     * close or a failing template never takes the data with it.
+     */
+    public drafts: FormDraftStore = makeNoopDraftStore();
     private templateService!: TemplateService;
 
     manageForms() {
@@ -206,6 +229,14 @@ export default class ModalFormPlugin extends Plugin {
         }
     }
 
+    async setPreserveFormDrafts(value: boolean) {
+        this.settings!.preserveFormDrafts = value;
+        if (!value) {
+            this.drafts.clearAll();
+        }
+        await this.saveSettings();
+    }
+
     async setAttachShortcutToGlobalWindow(value: boolean) {
         this.settings!.attachShortcutToGlobalWindow = value;
         this.attachShortcutToGlobalWindow();
@@ -249,25 +280,8 @@ export default class ModalFormPlugin extends Plugin {
                     id: `insert-template-${form.name}`,
                     name: `Insert template: ${form.name}`,
                     editorCallback: (editor, ctx) => {
-                        this.api.openForm(form).then((result) => {
-                            editor.replaceSelection(
-                                executeTemplate(form.template.parsedTemplate, result.getData()),
-                            );
-                            if (ctx instanceof MarkdownView) {
-                                logger.debug("Saving file after inserting form template");
-                                ctx.save().then(() => {
-                                    const file = ctx.file?.path;
-                                    if (!file) {
-                                        return;
-                                    }
-                                    // This gives obsidian some time to process the frontmatter and other things before asking templater to do its job
-                                    setImmediate(this.templateService.replaceVariablesInFile(file));
-                                });
-                            } else {
-                                notifyWarning("Cannot save file, editor is not a markdown view");
-                            }
-                        });
-                    }
+                        this.runInsertTemplateFlow(form, editor, ctx);
+                    },
                 });
                 commandsRegistered++;
             }
@@ -282,14 +296,11 @@ export default class ModalFormPlugin extends Plugin {
                             this.app,
                             [form],
                             ({ form: selectedForm, folder, noteName }) => {
-                                this.api.openForm(selectedForm).then((formData) => {
-                                    const noteContent = executeTemplate(selectedForm.template.parsedTemplate, formData.getData());
-                                    this.createNoteFromTemplate(noteName, noteContent, folder)();
-                                });
+                                this.runCreateNoteFlow(selectedForm, noteName, folder);
                             },
                         );
                         picker.open();
-                    }
+                    },
                 });
                 commandsRegistered++;
             }
@@ -311,6 +322,11 @@ export default class ModalFormPlugin extends Plugin {
             this.registerTemplateCommands();
             this.saveSettings(s);
         });
+        this.drafts = makeFormDraftStore(
+            appLocalStorage(this.app, DRAFTS_STORAGE_KEY, logger),
+            { isEnabled: () => this.settings?.preserveFormDrafts ?? true },
+        );
+        this.drafts.prune();
         this.api = new API(this.app, this);
         this.attachShortcutToGlobalWindow();
         this.templateService = getTemplateService(this.app, logger);
@@ -360,24 +376,7 @@ export default class ModalFormPlugin extends Plugin {
                     return;
                 }
                 const replaceWithForm = (form: FormWithTemplate) => {
-                    this.api.openForm(form).then((result) => {
-                        editor.replaceSelection(
-                            executeTemplate(form.template.parsedTemplate, result.getData()),
-                        );
-                        if (ctx instanceof MarkdownView) {
-                            logger.debug("Saving file after inserting form template");
-                            ctx.save().then(() => {
-                                const file = ctx.file?.path;
-                                if (!file) {
-                                    return;
-                                }
-                                // This gives obsidian some time to process the frontmatter and other things before asking templater to do its job
-                                setImmediate(this.templateService.replaceVariablesInFile(file));
-                            });
-                        } else {
-                            notifyWarning("Cannot save file, editor is not a markdown view");
-                        }
-                    });
+                    this.runInsertTemplateFlow(form, editor, ctx);
                 };
                 if (formsWithTemplates.length === 1) {
                     const form = formsWithTemplates[0] as FormWithTemplate;
@@ -402,6 +401,14 @@ export default class ModalFormPlugin extends Plugin {
             id: "import-form",
             name: "Import form",
             callback: () => this.openImportFormModal,
+        });
+
+        this.addCommand({
+            id: "recover-form-data",
+            name: "Recover form data",
+            callback: () => {
+                this.recoverFormData();
+            },
         });
 
         // This adds a settings tab so the user can configure various aspects of the plugin
@@ -443,54 +450,171 @@ export default class ModalFormPlugin extends Plugin {
         );
     }
 
-    createNoteFromTemplate(
+    /**
+     * Opens the retry form so the user can fix a template that could not be
+     * processed. Returns the fixed template, or nothing if they gave up.
+     */
+    private async askForTemplateFix(
+        errorMessage: string,
+        templateContent: string,
+    ): Promise<string | undefined> {
+        const result = await this.api.openForm(retryForm, {
+            values: { title: errorMessage, template: templateContent },
+            // The retry form is a plumbing detail. Its content is a rendered
+            // template, not user input, so it would only be noise in the
+            // recovery list.
+            preserveData: false,
+        });
+        if (result.status === "cancelled") return undefined;
+        const template = result.get("template");
+        if (typeof template !== "string") {
+            notifyWarning("Failed while retrying")("Template is not a string");
+            return undefined;
+        }
+        return template;
+    }
+
+    /**
+     * Tells the user the data they entered is still around, and how to get it back.
+     */
+    private keepDataForLater(form: FormDefinition) {
+        this.drafts.markPending(form.name);
+        // Nothing was kept if the user turned drafts off, so promising a
+        // recovery would be a lie.
+        if (O.isNone(this.drafts.find(form.name))) return;
+        log_notice(
+            "💾 Your form data was kept",
+            `Reopen "${form.title}" to continue where you left off, ` +
+                'or use the "Recover form data" command.',
+        );
+    }
+
+    /**
+     * Fills a form, renders its template and creates a note out of it.
+     * Every step that can fail reports what went wrong and gives the user the
+     * chance to retry without typing everything again.
+     */
+    async runCreateNoteFlow(
+        form: FormWithTemplate,
         noteName: string,
-        noteContent: string,
         destinationFolder: string,
-    ): TE.TaskEither<Error, void> {
-        const loop = (noteContent: string): TE.TaskEither<Error, void> => {
-            // Use template service instead of directly creating the file
-            return pipe(
-                this.templateService.createNoteFromTemplate(
-                    noteContent,
-                    destinationFolder,
-                    noteName,
-                    false, // don't open the new note
-                ),
-                TE.orElse((error) => {
-                    logger.error(error);
-                    return pipe(
-                        TE.tryCatch(
-                            () =>
-                                this.api.openForm(retryForm, {
-                                    values: {
-                                        title: error.message,
-                                        template: noteContent,
-                                    },
-                                }),
-                            E.toError,
-                        ),
-                        TE.map((result) => result.get("template")),
-                        TE.chain((template) => {
-                            if (typeof template !== "string") {
-                                notifyWarning("Failed while retrying")("Template is not a string");
-                                return TE.left(new Error("Template is not a string"));
-                            }
-                            return loop(template);
-                        }),
-                    );
-                }),
-            );
-        };
-        return pipe(
-            loop(noteContent),
-            TE.tapIO(() => () => {
+    ): Promise<void> {
+        let values: ModalFormData | undefined;
+        // Set when the user chose to fix the rendered template by hand, in
+        // which case we retry with it instead of asking for the data again.
+        let fixedContent: string | undefined;
+        for (;;) {
+            let noteContent: string;
+            if (fixedContent !== undefined) {
+                noteContent = fixedContent;
+                fixedContent = undefined;
+            } else {
+                const result = await this.api.openForm(form, values ? { values } : undefined);
+                if (result.status === "cancelled") return;
+                values = result.getData();
+                const rendered = renderTemplate(form.template.parsedTemplate, values);
+                if (E.isLeft(rendered)) {
+                    logger.error(rendered.left);
+                    const choice = await askTemplateFailure(this.app, {
+                        title: `The template of "${form.title}" could not be rendered`,
+                        message: describeTemplateError(rendered.left),
+                    });
+                    if (choice === "retry-form") continue;
+                    this.keepDataForLater(form);
+                    return;
+                }
+                noteContent = rendered.right;
+            }
+            const outcome = await this.templateService.createNoteFromTemplate(
+                noteContent,
+                destinationFolder,
+                noteName,
+                false, // don't open the new note
+            )();
+            if (E.isRight(outcome)) {
+                this.drafts.clear(form.name);
                 log_notice(
                     "Note created successfully",
                     `Note "${noteName}" created in ${destinationFolder}`,
                 );
-            }),
-        );
+                return;
+            }
+            logger.error(outcome.left);
+            const choice = await askTemplateFailure(this.app, {
+                title: `The note "${noteName}" could not be created`,
+                message: describeTemplateError(outcome.left),
+                canEditTemplate: true,
+            });
+            if (choice === "discard") {
+                this.keepDataForLater(form);
+                return;
+            }
+            if (choice === "edit-template") {
+                const fixed = await this.askForTemplateFix(
+                    describeTemplateError(outcome.left),
+                    noteContent,
+                );
+                if (fixed === undefined) {
+                    this.keepDataForLater(form);
+                    return;
+                }
+                fixedContent = fixed;
+            }
+            // "retry-form" falls through, reopening the form with the same values
+        }
+    }
+
+    /**
+     * Fills a form and inserts its rendered template at the cursor.
+     * The text is already in the note by the time templater runs, so there is
+     * nothing to retry here, but a failure must still be reported clearly.
+     */
+    async runInsertTemplateFlow(
+        form: FormWithTemplate,
+        editor: Editor,
+        ctx: MarkdownView | MarkdownFileInfo,
+    ): Promise<void> {
+        const result = await this.api.openForm(form);
+        if (result.status === "cancelled") return;
+        const rendered = renderTemplate(form.template.parsedTemplate, result.getData());
+        if (E.isLeft(rendered)) {
+            logger.error(rendered.left);
+            notifyError("The form template could not be rendered")(
+                describeTemplateError(rendered.left),
+            );
+            this.keepDataForLater(form);
+            return;
+        }
+        editor.replaceSelection(rendered.right);
+        if (!(ctx instanceof MarkdownView)) {
+            notifyWarning("Cannot save file, editor is not a markdown view")(
+                "The template was inserted, but we could not ask templater to process it.",
+            );
+            return;
+        }
+        logger.debug("Saving file after inserting form template");
+        await ctx.save();
+        const file = ctx.file?.path;
+        if (!file) {
+            this.drafts.clear(form.name);
+            return;
+        }
+        // This gives obsidian some time to process the frontmatter and other
+        // things before asking templater to do its job
+        const outcome = await new Promise<E.Either<Error, void>>((resolve) => {
+            setImmediate(() => {
+                this.templateService.replaceVariablesInFile(file)().then(resolve);
+            });
+        });
+        if (E.isLeft(outcome)) {
+            logger.error(outcome.left);
+            notifyError("Templater could not process the inserted template")(
+                `${describeTemplateError(outcome.left)}. The text was inserted in the note, ` +
+                    "but the templater commands inside it were not executed.",
+            );
+            return;
+        }
+        this.drafts.clear(form.name);
     }
 
     /**
@@ -500,24 +624,43 @@ export default class ModalFormPlugin extends Plugin {
      */
     createNoteFromForm() {
         const formsWithTemplates = this.getFormsWithTemplates();
-        const onFormSelected = async (
-            form: FormWithTemplate,
-            noteName: string,
-            destinationFolder: string,
-        ) => {
-            const formData = await this.api.openForm(form);
-            const noteContent = executeTemplate(form.template.parsedTemplate, formData.getData());
-
-            await this.createNoteFromTemplate(noteName, noteContent, destinationFolder)();
-        };
 
         const picker = new NewNoteModal(
             this.app,
             formsWithTemplates,
             ({ form, folder, noteName }) => {
-                onFormSelected(form, noteName, folder);
+                this.runCreateNoteFlow(form, noteName, folder);
             },
         );
         picker.open();
+    }
+
+    /**
+     * Reopens a form with data we kept from a previous, unfinished attempt.
+     * If the form is gone, at least show the data so it can be copied out.
+     */
+    private recoverDraft(draft: FormDraft) {
+        const form = this.validFormDefinitions.find((f) => f.name === draft.formName);
+        if (!form) {
+            log_notice(
+                `The form "${draft.formTitle}" no longer exists`,
+                `This is the data we had kept for it:\n${JSON.stringify(draft.data, null, 2)}`,
+            );
+            return;
+        }
+        this.api.openForm(form, { values: draft.data });
+    }
+
+    private recoverFormData() {
+        const drafts = this.drafts.list();
+        if (drafts.length === 0) {
+            log_notice(
+                "Nothing to recover",
+                "We have no saved form data. Data is only kept when a form is closed " +
+                    "without submitting, or when something fails after submitting it.",
+            );
+            return;
+        }
+        new DraftPickerModal(this.app, drafts, (draft) => this.recoverDraft(draft)).open();
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import {
 } from "./core/formDefinitionSchema";
 import {
     DRAFTS_STORAGE_KEY,
+    draftIdFor,
     makeFormDraftStore,
     makeNoopDraftStore,
     type FormDraft,
@@ -478,10 +479,10 @@ export default class ModalFormPlugin extends Plugin {
      * Tells the user the data they entered is still around, and how to get it back.
      */
     private keepDataForLater(form: FormDefinition) {
-        this.drafts.markPending(form.name);
+        this.drafts.markPending(draftIdFor(form));
         // Nothing was kept if the user turned drafts off, so promising a
         // recovery would be a lie.
-        if (O.isNone(this.drafts.find(form.name))) return;
+        if (O.isNone(this.drafts.find(draftIdFor(form)))) return;
         log_notice(
             "💾 Your form data was kept",
             `Reopen "${form.title}" to continue where you left off, ` +
@@ -532,7 +533,7 @@ export default class ModalFormPlugin extends Plugin {
                 false, // don't open the new note
             )();
             if (E.isRight(outcome)) {
-                this.drafts.clear(form.name);
+                this.drafts.clear(draftIdFor(form));
                 log_notice(
                     "Note created successfully",
                     `Note "${noteName}" created in ${destinationFolder}`,
@@ -596,7 +597,7 @@ export default class ModalFormPlugin extends Plugin {
         await ctx.save();
         const file = ctx.file?.path;
         if (!file) {
-            this.drafts.clear(form.name);
+            this.drafts.clear(draftIdFor(form));
             return;
         }
         // This gives obsidian some time to process the frontmatter and other
@@ -614,7 +615,7 @@ export default class ModalFormPlugin extends Plugin {
             );
             return;
         }
-        this.drafts.clear(form.name);
+        this.drafts.clear(draftIdFor(form));
     }
 
     /**

--- a/src/std/debounce.test.ts
+++ b/src/std/debounce.test.ts
@@ -1,0 +1,44 @@
+import { debounce } from "./index";
+
+describe("debounce", () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it("runs only the last call of a burst", () => {
+        const spy = jest.fn();
+        const debounced = debounce(spy, 100);
+        debounced("a");
+        debounced("b");
+        debounced("c");
+        expect(spy).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(100);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith("c");
+    });
+
+    it("flush runs the pending call right away", () => {
+        const spy = jest.fn();
+        const debounced = debounce(spy, 100);
+        debounced("a");
+        debounced.flush();
+        expect(spy).toHaveBeenCalledWith("a");
+        jest.advanceTimersByTime(1000);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("flush does nothing when there is nothing pending", () => {
+        const spy = jest.fn();
+        const debounced = debounce(spy, 100);
+        debounced.flush();
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("cancel forgets the pending call", () => {
+        const spy = jest.fn();
+        const debounced = debounce(spy, 100);
+        debounced("a");
+        debounced.cancel();
+        jest.advanceTimersByTime(1000);
+        expect(spy).not.toHaveBeenCalled();
+    });
+});

--- a/src/std/index.ts
+++ b/src/std/index.ts
@@ -90,6 +90,51 @@ export function throttle(fn: (...args: unknown[]) => unknown, ms = 100) {
     };
 }
 
+export interface Debounced<T extends unknown[]> {
+    (...args: [...T]): void;
+    /** Runs the pending call right away, if there is one. */
+    flush(): void;
+    /** Forgets the pending call, if there is one. */
+    cancel(): void;
+}
+
+/**
+ * Delays the execution of `cb` until `ms` have passed without new calls.
+ * Unlike `throttle`, the trailing call is guaranteed to run, which makes it
+ * suitable for saving state the user is still editing.
+ * The returned function exposes `flush` and `cancel` so callers can decide
+ * what to do with the pending call when they are done with it.
+ */
+export function debounce<T extends unknown[]>(
+    cb: (...args: [...T]) => void,
+    ms = 100,
+): Debounced<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let pending: [...T] | undefined;
+    function run() {
+        timer = undefined;
+        if (pending === undefined) return;
+        const args = pending;
+        pending = undefined;
+        cb(...args);
+    }
+    const debounced = (...args: [...T]) => {
+        pending = args;
+        if (timer !== undefined) clearTimeout(timer);
+        timer = setTimeout(run, ms);
+    };
+    debounced.flush = () => {
+        if (timer !== undefined) clearTimeout(timer);
+        run();
+    };
+    debounced.cancel = () => {
+        if (timer !== undefined) clearTimeout(timer);
+        timer = undefined;
+        pending = undefined;
+    };
+    return debounced;
+}
+
 export function tap(msg: string) {
     return <T>(x: T) => {
         console.log(msg, x);

--- a/src/suggesters/DraftPickerModal.ts
+++ b/src/suggesters/DraftPickerModal.ts
@@ -1,0 +1,34 @@
+import { App, FuzzySuggestModal } from "obsidian";
+import type { FormDraft } from "src/core/formDrafts";
+
+function describeDraft(draft: FormDraft): string {
+    const when = new Date(draft.savedAt).toLocaleString();
+    const fields = Object.keys(draft.data).length;
+    const state = draft.status === "pending" ? "not submitted" : "submitted";
+    return `${draft.formTitle} — ${fields} field${fields === 1 ? "" : "s"}, ${state}, ${when}`;
+}
+
+/** Lets the user pick one of the form drafts we kept around */
+export class DraftPickerModal extends FuzzySuggestModal<FormDraft> {
+    constructor(
+        app: App,
+        private drafts: FormDraft[],
+        private onSelected: (draft: FormDraft) => void,
+    ) {
+        super(app);
+        this.setPlaceholder("Pick the form data you want to recover");
+    }
+
+    getItems(): FormDraft[] {
+        return this.drafts;
+    }
+
+    getItemText(item: FormDraft): string {
+        return describeDraft(item);
+    }
+
+    onChooseItem(item: FormDraft, _: MouseEvent | KeyboardEvent): void {
+        this.close();
+        this.onSelected(item);
+    }
+}

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -13,6 +13,12 @@ declare module "obsidian" {
 
     interface App {
         appId?: string;
+        /**
+         * Vault scoped local storage. Added in Obsidian 1.5, and our declared
+         * minimum app version is older, hence optional.
+         */
+        loadLocalStorage?(key: string): unknown;
+        saveLocalStorage?(key: string, data: unknown | null): void;
         plugins: {
             enabledPlugins: Set<string>;
             plugins: {

--- a/src/utils/appLocalStorage.ts
+++ b/src/utils/appLocalStorage.ts
@@ -1,0 +1,46 @@
+import { App } from "obsidian";
+import type { DraftStorage } from "src/core/formDrafts";
+import type { Logger } from "./Logger";
+
+/**
+ * Obsidian exposes a vault scoped local storage through `App.loadLocalStorage`
+ * and `App.saveLocalStorage`. It is the intended place for data that is
+ * disposable, machine local and not worth putting in `data.json`, which is
+ * exactly what an in-progress form is.
+ *
+ * Those methods only exist since Obsidian 1.5, and our declared minimum app
+ * version is older than that, so we feature detect them and fall back to
+ * `window.localStorage` using the same key shape Obsidian itself uses.
+ */
+export function appLocalStorage(app: App, key: string, logger: Logger): DraftStorage {
+    const fallbackKey = `${app.appId ?? "modal-form"}-${key}`;
+    return {
+        load() {
+            try {
+                if (typeof app.loadLocalStorage === "function") {
+                    return app.loadLocalStorage(key);
+                }
+                const raw = window.localStorage.getItem(fallbackKey);
+                return raw === null ? null : JSON.parse(raw);
+            } catch (error) {
+                logger.error("Could not read local storage", key, error);
+                return null;
+            }
+        },
+        save(value) {
+            try {
+                if (typeof app.saveLocalStorage === "function") {
+                    app.saveLocalStorage(key, value);
+                    return;
+                }
+                if (value === null) {
+                    window.localStorage.removeItem(fallbackKey);
+                } else {
+                    window.localStorage.setItem(fallbackKey, JSON.stringify(value));
+                }
+            } catch (error) {
+                logger.error("Could not write local storage", key, error);
+            }
+        },
+    };
+}

--- a/src/views/EditFormView.ts
+++ b/src/views/EditFormView.ts
@@ -70,7 +70,9 @@ export class EditFormView extends ItemView {
                     this.plugin.closeEditForm();
                 },
                 onPreview: async (formDefinition: FormDefinition) => {
-                    const result = await this.plugin.api.openForm(formDefinition);
+                    const result = await this.plugin.api.openForm(formDefinition, {
+                        preserveData: false,
+                    });
                     const result_str = JSON.stringify(result, null, 2);
                     log_notice("Form result", result_str);
                     console.log(result_str);

--- a/src/views/ManageFormsView.ts
+++ b/src/views/ManageFormsView.ts
@@ -62,7 +62,9 @@ export class ManageFormsView extends ItemView {
                 },
                 previewForm: async (form: FormDefinition) => {
                     try {
-                        const result = await this.plugin.api.openForm(form);
+                        const result = await this.plugin.api.openForm(form, {
+                            preserveData: false,
+                        });
                         const result_str = JSON.stringify(result, null, 2);
                         log_notice("Form result", result_str);
                     } catch (error) {

--- a/src/views/TemplateFailureModal.ts
+++ b/src/views/TemplateFailureModal.ts
@@ -1,0 +1,84 @@
+import { App, Modal, Setting } from "obsidian";
+
+export type TemplateFailureChoice = "retry-form" | "edit-template" | "discard";
+
+export type TemplateFailureOptions = {
+    /** Short description of what could not be done, e.g. "The note could not be created" */
+    title: string;
+    /** The actual error, as close to the original wording as possible */
+    message: string;
+    /** Whether editing the rendered template by hand can help */
+    canEditTemplate?: boolean;
+};
+
+/**
+ * Tells the user exactly what went wrong after a form was already filled in,
+ * and lets them pick how to recover. Whatever they choose, the data they
+ * entered is never thrown away silently.
+ */
+class TemplateFailureModal extends Modal {
+    private choice: TemplateFailureChoice = "discard";
+
+    constructor(
+        app: App,
+        private options: TemplateFailureOptions,
+        private onChoice: (choice: TemplateFailureChoice) => void,
+    ) {
+        super(app);
+    }
+
+    private choose(choice: TemplateFailureChoice) {
+        this.choice = choice;
+        this.close();
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.addClass("modal-form-template-failure");
+        contentEl.createEl("h2", { text: `🚨 ${this.options.title}` });
+        contentEl.createEl("p", {
+            text: "This is what went wrong:",
+        });
+        contentEl.createEl("pre", {
+            text: this.options.message,
+            cls: "modal-form-error-details",
+        });
+        contentEl.createEl("p", {
+            text:
+                "Nothing you typed has been lost. You can reopen the form with the same data, " +
+                "or dismiss this and recover the data later with the " +
+                '"Recover form data" command.',
+        });
+
+        const actions = new Setting(contentEl);
+        actions.addButton((btn) =>
+            btn.setButtonText("Discard").onClick(() => this.choose("discard")),
+        );
+        if (this.options.canEditTemplate) {
+            actions.addButton((btn) =>
+                btn.setButtonText("Fix the template").onClick(() => this.choose("edit-template")),
+            );
+        }
+        actions.addButton((btn) =>
+            btn
+                .setButtonText("Reopen form")
+                .setCta()
+                .onClick(() => this.choose("retry-form")),
+        );
+    }
+
+    onClose() {
+        this.contentEl.empty();
+        this.onChoice(this.choice);
+    }
+}
+
+/** Opens the failure modal and resolves with whatever the user picked */
+export function askTemplateFailure(
+    app: App,
+    options: TemplateFailureOptions,
+): Promise<TemplateFailureChoice> {
+    return new Promise((resolve) => {
+        new TemplateFailureModal(app, options, resolve).open();
+    });
+}

--- a/styles.css
+++ b/styles.css
@@ -124,3 +124,15 @@ If your plugin does not need CSS, delete this file.
         flex-wrap: wrap;
     }
 }
+
+.modal-form-template-failure .modal-form-error-details {
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 12rem;
+    overflow-y: auto;
+    padding: 0.75rem;
+    border-radius: var(--radius-s);
+    background-color: var(--background-secondary);
+    color: var(--text-error);
+    font-size: var(--font-ui-small);
+}


### PR DESCRIPTION
## What

Filling a long form and losing everything because a template had a typo, because Templater choked on a command, or because the modal was dismissed by accident, was the most annoying way this plugin could fail. This adds a safety net so that never costs more than a couple of clicks.

## Where the data goes

While a form is open its values are written to Obsidian's vault scoped local storage — `App.loadLocalStorage` / `App.saveLocalStorage`. That is exactly what those APIs are for: disposable, machine local data that has no business being in `data.json` or in the vault.

They only exist since Obsidian 1.5 and our declared `minAppVersion` is older, so they are feature detected with a `window.localStorage` fallback using the same key shape Obsidian itself uses. The typings we pin (obsidian 1.4.11) don't declare them, so they are added as optional members in `src/typings/obsidian-ex.d.ts`.

Only values that survive a round trip are stored (text, numbers, booleans, lists of them). File and image selections are dropped rather than restored as something broken. Drafts expire after a week, are capped at 25 forms, and are pruned on load.

## Behaviour

**Accidental close.** Closing with the `X`, clicking outside, or losing Obsidian keeps the data; the next open of that form restores it and says so in a notice. `Cancel` and `Escape` stay a deliberate discard and delete the draft.

**Template failure.** `createNoteFromTemplate` used to swallow the error into a generic *"We are not sure about what it is"* retry form, and the insert-template flows discarded the `TaskEither` result entirely, so Templater errors there were invisible. Now failures unwrap the real cause and show it in a dialog with three ways out:

- **Reopen form** — the form opens again with everything already typed
- **Fix the template** — the existing hand-edit retry, kept for when the template itself is broken
- **Discard** — nothing is lost, the data stays recoverable

Insert flows can't retry (the text is already in the note), so they only report, clearly.

**Everything else.** A new `Recover form data` command lists what we kept, newest first, and reopens the chosen form prefilled. This covers the case the plugin can't observe: a user's own Templater/QuickAdd script throwing after `openForm` resolved. That's why submitting marks a draft as `submitted` rather than deleting it — it stops auto-restoring, but stays recoverable.

**Opting out.** A `Preserve form data` setting turns it all off and deletes what was kept. Single opens can pass `preserveData: false`; form previews in the editor now do, so trying out a form you're editing can't pollute the real one's draft.

## Changes

| File | |
|---|---|
| `src/core/formDrafts.ts` | draft model, validation, pruning and store (new) |
| `src/utils/appLocalStorage.ts` | Obsidian local storage adapter with fallback (new) |
| `src/core/template/renderTemplate.ts` | non-throwing render + error cause unwrapping (new) |
| `src/views/TemplateFailureModal.ts` | the failure dialog (new) |
| `src/suggesters/DraftPickerModal.ts` | picker for the recover command (new) |
| `src/FormModal.ts` | autosave, restore, lifecycle |
| `src/main.ts` | the three template flows rewritten as recoverable loops |
| `src/std/index.ts` | `debounce` with `flush`/`cancel` (`throttle` is leading-edge, so it drops the last keystrokes) |
| `docs/data-recovery.md` | user facing docs (new) |

## Testing

`npm run build && npm run test` both pass. 47 new tests across `formDrafts.test.ts`, `renderTemplate.test.ts` and `debounce.test.ts` covering the draft lifecycle (save/recover/submit/pending/clear/disable), corrupted and partial storage payloads, expiry and capping, error cause unwrapping including a self-referencing cause, and debounce semantics.

Not covered by automated tests: the modal wiring and the recovery flows in `main.ts`, since Svelte components and Obsidian modals aren't under Jest in this repo. Those want a manual pass in the example vault — in particular an intentionally broken Templater command in a "create note from template" form.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZBwtiirPMV9fccWDUJxn9)_