### PR TITLE
fix: show required indicator on select, toggle, folder, note, dataview, textarea fields

### DIFF
--- a/src/views/components/Form/InputDataview.svelte
+++ b/src/views/components/Form/InputDataview.svelte
@@ -16,6 +16,7 @@
     export let app: App;
     export let errors: Readable<string[]>;
     export let form: FormEngine;
+    export let required = false;
 
     let suggester: DataviewSuggest | null = null;
 
@@ -38,6 +39,7 @@
 
 <ObsidianInputWrapper
     {errors}
+    {required}
     name={field.name}
     label={field.label || field.name}
     description={field.description}

--- a/src/views/components/Form/InputFolder.svelte
+++ b/src/views/components/Form/InputFolder.svelte
@@ -9,6 +9,7 @@
     export let value: Writable<FieldValue>;
     export let parentFolder: string | undefined;
     export let app: App;
+    export let required = false;
     let search_: SearchComponent | undefined;
     function customizer(setting: Setting) {
         setting.addSearch((component) => {
@@ -35,6 +36,7 @@
         name: field.label || field.name,
         description: field.description || "",
         fieldName: field.name,
+        required,
         customizer,
     }}
 >

--- a/src/views/components/Form/InputNote.svelte
+++ b/src/views/components/Form/InputNote.svelte
@@ -11,6 +11,7 @@
     export let value: Writable<FieldValue>;
     export let app: App;
     export let errors: Readable<string[]>;
+    export let required = false;
     function noteSuggest(el: HTMLInputElement) {
         new FileSuggest(
             app,
@@ -30,6 +31,7 @@
 
 <ObsidianInputWrapper
     {errors}
+    {required}
     name={field.name}
     label={field.label || field.name}
     description={field.description}

--- a/src/views/components/Form/InputTextArea.svelte
+++ b/src/views/components/Form/InputTextArea.svelte
@@ -7,6 +7,7 @@
     export let field: FieldDefinition;
     export let value: Writable<FieldValue>;
     export let errors: Readable<string[]>;
+    export let required = false;
     function customizeTextArea(el: HTMLTextAreaElement) {
         if (Platform.isIosApp) el.style.width = "100%";
         else if (Platform.isDesktopApp) {
@@ -17,6 +18,7 @@
 
 <ObsidianInputWrapper
     {errors}
+    {required}
     name={field.name}
     label={field.label || field.name}
     description={field.description}

--- a/src/views/components/Form/ObsidianSelect.svelte
+++ b/src/views/components/Form/ObsidianSelect.svelte
@@ -13,6 +13,7 @@
     export let value: Writable<FieldValue>;
     export let app: App;
     export let errors: Readable<string[]>;
+    export let required = false;
     function getNoteOptions(folder: string): Record<string, string> {
         const files = get_tfiles_from_folder(folder, app);
         return pipe(
@@ -34,6 +35,7 @@
 
 <ObsidianInput
     {errors}
+    {required}
     name={field.name}
     label={field.label || field.name}
     description={field.description}

--- a/src/views/components/Form/ObsidianToggle.svelte
+++ b/src/views/components/Form/ObsidianToggle.svelte
@@ -6,6 +6,7 @@
     import { useSetting } from "./useObsidianSetting";
     export let field: FieldDefinition;
     export let value: Writable<FieldValue>;
+    export let required = false;
     let toggle_: ToggleComponent | undefined;
     function customizer(setting: Setting) {
         setting.addToggle((toggle) => {
@@ -25,6 +26,7 @@
         name: field.label || field.name,
         description: field.description || "",
         fieldName: field.name,
+        required,
         customizer,
     }}
 >

--- a/src/views/components/Form/RenderField.svelte
+++ b/src/views/components/Form/RenderField.svelte
@@ -53,15 +53,23 @@
     </ObsidianInputWrapper>
 {:else if $isVisible.right}
     {#if definition.input.type === "select"}
-        <ObsidianSelect input={definition.input} field={definition} {value} {errors} {app} />
+        <ObsidianSelect
+            input={definition.input}
+            field={definition}
+            {value}
+            {errors}
+            {app}
+            required={definition.isRequired}
+        />
     {:else if definition.input.type === "toggle"}
-        <ObsidianToggle field={definition} {value} />
+        <ObsidianToggle field={definition} {value} required={definition.isRequired} />
     {:else if definition.input.type === "folder"}
         <InputFolder
             field={definition}
             parentFolder={definition.input.parentFolder}
             {value}
             {app}
+            required={definition.isRequired}
         />
     {:else if definition.input.type === "dataview"}
         <InputDataview
@@ -71,11 +79,19 @@
             {errors}
             {app}
             form={formEngine}
+            required={definition.isRequired}
         />
     {:else if definition.input.type === "note"}
-        <InputNote field={definition} input={definition.input} {value} {errors} {app} />
+        <InputNote
+            field={definition}
+            input={definition.input}
+            {value}
+            {errors}
+            {app}
+            required={definition.isRequired}
+        />
     {:else if definition.input.type === "textarea"}
-        <InputTextArea field={definition} {value} {errors} />
+        <InputTextArea field={definition} {value} {errors} required={definition.isRequired} />
     {:else if definition.input.type === "markdown_block"}
         <MarkdownBlock field={definition.input} form={formEngine} {app} />
     {:else if definition.input.type === "document_block"}

--- a/src/views/components/Form/useObsidianSetting.ts
+++ b/src/views/components/Form/useObsidianSetting.ts
@@ -6,6 +6,7 @@ export function useSetting(
         name: string;
         description: string;
         fieldName?: string;
+        required?: boolean;
         customizer?: (setting: Setting) => void;
     },
 ) {
@@ -15,5 +16,14 @@ export function useSetting(
         .then(field.customizer || (() => {}));
     if (field.fieldName) {
         setting.settingEl.setAttribute("data-field-name", field.fieldName);
+    }
+    // Match the ObsidianInputWrapper styling: append a red asterisk after
+    // the field name so required-field indicators are consistent across
+    // every field type, including the ones (toggle, folder) that render
+    // through Obsidian's native Setting rather than our own wrapper.
+    if (field.required) {
+        setting.nameEl.appendChild(
+            createSpan({ cls: "modal-form-required", text: "*" }),
+        );
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,10 @@ If your plugin does not need CSS, delete this file.
 .modal-form-hint {
     color: var(--text-muted);
 }
+.modal-form-required {
+    color: var(--color-red);
+    margin-left: 0.25em;
+}
 .modal-form {
     --shadow-bottom: 0 0.8rem 0.8rem -0.8rem;
 }


### PR DESCRIPTION
## Summary

The red asterisk that marks a field as required only rendered on some field types. Six input types silently swallowed the flag and showed no indicator even when `isRequired: true` was set on the field definition, breaking the visual contract users rely on to know which fields must be filled.

## What was broken

`RenderField.svelte` already passes `required={definition.isRequired}` to `ObsidianInputWrapper` for the input types it wraps inline (text, number, date, time, textarea inputs handled by `InputField`, plus multiselect, slider, tag, image, file).

The other components render their own wrapper or Setting internally and never accepted a `required` prop, so the flag was dropped:

| Field type | Component | Why the asterisk was missing |
|---|---|---|
| `select` | `ObsidianSelect.svelte` | wraps itself with `ObsidianInputWrapper`, prop not forwarded |
| `dataview` | `InputDataview.svelte` | wraps itself with `ObsidianInputWrapper`, prop not forwarded |
| `note` | `InputNote.svelte` | wraps itself with `ObsidianInputWrapper`, prop not forwarded |
| `textarea` | `InputTextArea.svelte` | wraps itself with `ObsidianInputWrapper`, prop not forwarded |
| `toggle` | `ObsidianToggle.svelte` | renders through `useSetting` action, no wrapper at all |
| `folder` | `InputFolder.svelte` | renders through `useSetting` action, no wrapper at all |

## Changes

- Add a `required` prop to each of the six components and forward it to their wrapper.
- Pass `required={definition.isRequired}` from `RenderField.svelte` down to each of those components.
- Extend `useSetting` with a `required` option that appends a shared `.modal-form-required` asterisk to the setting's name element, so `toggle` and `folder` (which don't use `ObsidianInputWrapper`) get the same visual indicator.
- Add a new global `.modal-form-required` CSS class in `styles.css` styled with `var(--color-red)`, matching the local `.required` style used by `ObsidianInputWrapper`.

## Verification

- `npm run build` — passes (existing warnings are pre-existing, unrelated to this change).
- `npm run test` — 228 passed, 2 skipped, same as baseline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bea6a4wKAtWbSfA7iqgtGX)_