### PR TITLE
fix: round-trip serialization of frontmatter template command

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -10,7 +10,7 @@ After the form template is processed, if you have the templater plugin installed
 A template consists of plain text mixed with variables and commands:
 
 - Variables: Wrapped in double curly braces `{{ }}`, they are replaced with form field values
-- Commands: Special instructions wrapped in `{{# #}}` that control template behavior
+- Commands: Special instructions wrapped in `{# #}` that control template behavior
 
 ### Variables
 

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -3,7 +3,12 @@ import * as E from "fp-ts/Either";
 import { stringifyYaml } from "obsidian";
 import * as S from "parser-ts/string";
 import { FileProxy } from "../files/FileProxy";
-import { anythingUntilOpenOrEOF, executeTemplate, parseTemplate } from "./templateParser";
+import {
+    anythingUntilOpenOrEOF,
+    executeTemplate,
+    parsedTemplateToString,
+    parseTemplate,
+} from "./templateParser";
 
 const inspect = (val: unknown) => {
     console.dir(val, { depth: 10 });
@@ -466,5 +471,50 @@ describe("parseTemplate", () => {
             E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
         );
         expect(result).toEqual(E.of(""));
+    });
+});
+
+// `parsedTemplateToString` is used by the form-editor UI to load an existing
+// template back into the textarea. If the round-trip produces something the
+// parser cannot re-read, editing a saved template silently corrupts it.
+describe("parsedTemplateToString round-trip", () => {
+    const roundTrip = (template: string): string => {
+        const parsed = parseTemplate(template);
+        if (E.isLeft(parsed)) throw new Error(parsed.left);
+        return parsedTemplateToString(parsed.right);
+    };
+
+    it("preserves plain text", () => {
+        const template = "Hello world";
+        expect(roundTrip(template)).toEqual(template);
+    });
+
+    it("preserves a variable", () => {
+        const template = "Hello {{name}}!";
+        expect(roundTrip(template)).toEqual(template);
+    });
+
+    it("preserves a variable with a transformation", () => {
+        const template = "Hello {{name|upper}}!";
+        expect(roundTrip(template)).toEqual(template);
+    });
+
+    it("preserves a bare frontmatter command", () => {
+        const template = "{# frontmatter #}";
+        expect(roundTrip(template)).toEqual(template);
+    });
+
+    it("preserves a frontmatter command with pick values", () => {
+        const template = "{# frontmatter pick: name, age #}";
+        expect(roundTrip(template)).toEqual(template);
+    });
+
+    it("produces a template the parser can re-read after a round-trip", () => {
+        const template =
+            "---\n{# frontmatter pick: title, tags #}\n---\n\n# {{title|capitalize}}\n";
+        const back = roundTrip(template);
+        // Re-parsing the serialised output must succeed; the previous
+        // implementation emitted `{{# ... #}}` which broke this.
+        expect(E.isRight(parseTemplate(back))).toBe(true);
     });
 });

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -178,10 +178,16 @@ function tokenToString(token: Token): string {
             return token.value;
         case "variable":
             return `{{${token.value}${token.transformation ? `|${token.transformation}` : ""}}}`;
-        case "frontmatter-command":
-            return `{{# frontmatter pick: ${token.pick.join(", ")}, omit: ${token.omit.join(
-                ", ",
-            )} #}}`;
+        case "frontmatter-command": {
+            // Commands use single-brace delimiters `{# #}` — matching the parser above
+            // (`commandOpen` / `commandClose`) so the round-trip parses back cleanly.
+            // Only emit option labels when they have values: an empty `pick:` list
+            // isn't accepted by the parser, and `omit:` isn't a parseable option at all,
+            // so serialising it would produce a template the editor cannot re-parse.
+            const parts = ["frontmatter"];
+            if (token.pick.length > 0) parts.push(`pick: ${token.pick.join(", ")}`);
+            return `{# ${parts.join(" ")} #}`;
+        }
         default:
             return absurd(tag);
     }


### PR DESCRIPTION
## Summary

`parsedTemplateToString` — used by the form-editor UI to reload a saved template into the textarea — did not produce a valid template when the source contained a `{# frontmatter #}` command. The output could not be re-parsed, so reopening a form with a frontmatter command silently corrupted the template.

## The bug

`tokenToString` emitted frontmatter commands like this:

```
{{# frontmatter pick: name, age, omit:  #}}
```

Two things were wrong with that output:

1. **Delimiters.** The parser uses single-brace `{# #}` (see `commandOpen` / `commandClose` in `templateParser.ts`). The serializer used double-brace `{{# #}}`, so the round-trip fails.
2. **Empty option labels.** `pick:` and `omit:` were always appended, even when their arrays were empty. `omit:` is not a parseable option at all — only `pick:` is supported — and an empty `pick:` list is a parse error.

Concretely, `{# frontmatter #}` round-tripped to `{{# frontmatter pick: , omit:  #}}`, which the parser rejects.

## The fix

- Emit `{# frontmatter #}` (single-brace, matching the parser).
- Only include `pick:` when there are values; drop the unparseable `omit:` label entirely.
- Add explanatory comments so a future reader doesn't reintroduce either mistake.

## Tests

Added a `parsedTemplateToString round-trip` suite in `templateParser.test.ts` covering plain text, variables, transformations, bare `{# frontmatter #}`, `{# frontmatter pick: … #}`, and a realistic template (frontmatter fence + variable + transformation). Each test parses → serializes → asserts that either the string is preserved or the serialized output re-parses cleanly.

Full suite: `234 passed, 2 skipped`. `npm run build` also passes.

## Docs

`docs/templates.md` said commands are wrapped in `{{# #}}` while every example in the same file used the real `{# #}` delimiters. Corrected the description to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na6N8aLbfGA93TAojgCnqW)_