### PR TITLE
feat: accept `lowercase` as an alias for the `lower` transformation

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -58,18 +58,20 @@ This is a {{variableName}}. And this is also a valid {{ variableName }}
 
 The following transformations can be applied to variables:
 
-1. **`upper`**: Converts the variable's value to uppercase.
+1. **`upper`** (alias: **`uppercase`**): Converts the variable's value to uppercase.
    - Usage:
 
      ```plaintext
      {{ name | upper }}
+     {{ name | uppercase }}
      ```
 
-2. **`lower`**: Converts the variable's value to lowercase.
+2. **`lower`** (alias: **`lowercase`**): Converts the variable's value to lowercase.
    - Usage:
 
      ```plaintext
      {{ name | lower }}
+     {{ name | lowercase }}
      ```
 
 3. **`trim`**: Removes whitespace from both ends of the variable's value.

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -162,6 +162,35 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("Hello, john! You are 18 years old."));
     });
 
+    // `uppercase` and `lowercase` are documented aliases for `upper` and `lower`
+    // that read more naturally in prose templates. Both must parse to the same
+    // canonical transformation so the executor treats them identically.
+    it("should accept `uppercase` as an alias for `upper`", () => {
+        const template = "{{name|uppercase}}";
+        const result = parseTemplate(template);
+        expect(result).toEqual(
+            E.of([{ _tag: "variable", value: "name", transformation: "upper" }]),
+        );
+    });
+
+    it("should accept `lowercase` as an alias for `lower`", () => {
+        const template = "{{name|lowercase}}";
+        const result = parseTemplate(template);
+        expect(result).toEqual(
+            E.of([{ _tag: "variable", value: "name", transformation: "lower" }]),
+        );
+    });
+
+    it("Should execute a template with the `lowercase` alias", () => {
+        const template = "Hello, {{name|lowercase}}!";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { name: "John", age: 18 })),
+        );
+        expect(result).toEqual(E.of("Hello, john!"));
+    });
+
     it("Should execute a template with trim transformations", () => {
         const template = "Hello, {{name|trim}}!";
         const parsed = parseTemplate(template);

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -16,10 +16,11 @@ const TemplateTextSchema = object({
 });
 
 const upper = transform(enumType(["upper", "uppercase"]), (_) => "upper" as const);
+const lower = transform(enumType(["lower", "lowercase"]), (_) => "lower" as const);
 
 export const transformations = union([
     upper,
-    literal("lower"),
+    lower,
     literal("trim"),
     literal("stringify"),
     literal("capitalize"),


### PR DESCRIPTION
## Summary

Templates already accept `uppercase` as an alias for the `upper` transformation (both parse to the canonical `upper`), but the equivalent alias for `lower` was missing:

```markdown
{{ name | uppercase }}   ✅ works — canonicalises to `upper`
{{ name | lowercase }}   ❌ silently ignored (unknown transformation)
```

This asymmetry is easy to trip over when writing prose templates where `uppercase`/`lowercase` read more naturally than `upper`/`lower`. And because unknown transformations are silently dropped ("If an invalid transformation is specified, it will be silently ignored"), the typo produces plain unformatted output rather than an error — so users may not notice for a while.

## Changes

- `src/core/template/templateSchema.ts` — declare `lowercase` alongside `lower` using the same `transform(enumType(...))` pattern already used by `upper`. Both aliases parse to the canonical `"lower"` so the executor and the round-trip serialiser (`parsedTemplateToString`) need no other change.
- `docs/templates.md` — document both alias pairs (`upper`/`uppercase` and `lower`/`lowercase`). The `uppercase` alias existed but was previously undocumented.
- `src/core/template/templateParser.test.ts` — add three tests: `uppercase` parses to `upper` (regression coverage for the pre-existing alias), `lowercase` parses to `lower`, and `{{ name | lowercase }}` executes to the lowercased value end-to-end.

## Notes

- Round-trip is unchanged: `{{ name | lowercase }}` re-serialises to `{{ name | lower }}`, same as `{{ name | uppercase }}` already re-serialises to `{{ name | upper }}` today. Both aliases are input-only conveniences.
- No new user-facing config, migration, or FormBuilder API surface — the alias is picked up wherever `applyTransformation` is used (templates, `FormResult.asString`).

## Testing

- `npm run test` — 237 passed, 2 skipped (pre-existing).
- `npm run build` — clean (lint + svelte-check + esbuild); the 5 warnings are pre-existing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqecG98WMfCFLnZuVeGrRU)_