### PR TITLE
feat: add `pascal` template transformation

### DIFF
--- a/docs/ResultValue.md
+++ b/docs/ResultValue.md
@@ -88,7 +88,7 @@ The above code will print the list field as a bullet list, but all the values wi
 The map method takes a function that takes the value and returns a new value.
 It can be used when none of the provided printing are enough for your use case, or when one of them is almost what you need but you need to transform the value a bit more.
 
-### `trimmed`,`lower`,`upper`,`capitalized`,`slug`,`snake` shortcuts
+### `trimmed`,`lower`,`upper`,`capitalized`,`slug`,`snake`,`pascal` shortcuts
 
 The ResultValue class provides some shortcuts to common transformations of the value.
 They are:
@@ -99,6 +99,7 @@ They are:
 - `capitalized`: Uppercases the first character and leaves the rest untouched. Chain after `lower` (e.g. `result.getValue('name').lower.capitalized`) if you also want the remaining characters lowercased.
 - `slug`: Converts the value to a URL/filename-friendly slug. Lowercases the value, turns whitespace and underscores into `-`, strips punctuation, collapses runs of dashes, and trims edge dashes. Unicode letters/numbers are preserved so `Café Noël` becomes `café-noël`. Handy for turning a form's title into a filename: `result.getValue('title').slug`.
 - `snake`: Converts the value to `snake_case`. Same shape as `slug`, but whitespace and dashes become underscores, runs of underscores collapse, and edge underscores are trimmed. Unicode letters/numbers are preserved so `Café Noël` becomes `café_noël`. Handy for deriving variable names, YAML keys, or database columns: `result.getValue('title').snake`.
+- `pascal`: Converts the value to `PascalCase`. Any run of non-letter/number characters (whitespace, dashes, underscores, punctuation) becomes a word boundary; each remaining chunk's first character is upper-cased while the rest is preserved, so `hello world` becomes `HelloWorld` and `helloWorld` becomes `HelloWorld`. Unicode letters/numbers are preserved so `Café Noël 2024` becomes `CaféNoël2024`. Handy for deriving type names, class names, or wiki article titles: `result.getValue('title').pascal`.
 
 All of these shortcuts return a new ResultValue object, so you can chain them with other methods.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -118,6 +118,18 @@ The following transformations can be applied to variables:
 
    - Input `Hello, World!` produces `hello_world`; input `  My Note (2024)  ` produces `my_note_2024`.
 
+8. **`pascal`**: Converts the variable's value to `PascalCase`.
+   - Any run of non-letter/number characters (whitespace, dashes, underscores, punctuation) becomes a word boundary. The first character of each chunk is upper-cased and the rest of the chunk is preserved as-is, so an already-camelCased identifier like `helloWorld` becomes `HelloWorld` and edge separators are dropped.
+   - Unicode letters and numbers are preserved (e.g. `Café Noël 2024` → `CaféNoël2024`).
+   - Useful for deriving type names, class names, or wiki article titles from free-form text.
+   - Usage:
+
+     ```plaintext
+     {{ title | pascal }}
+     ```
+
+   - Input `hello world` produces `HelloWorld`; input `hello_world-my.note` produces `HelloWorldMyNote`; input `  ---My Note (2024)  ` produces `MyNote2024`.
+
 ### Example Templates
 
 Here are some examples of how to use the new template syntax:

--- a/src/core/FormResult.ts
+++ b/src/core/FormResult.ts
@@ -75,9 +75,9 @@ export default class FormResult {
      * Variables use the `{{ key }}` syntax. Optional whitespace is allowed
      * around the key, and a transformation can be applied with `|`, e.g.
      * `{{ key | upper }}`. Supported transformations match the ones used by
-     * form templates: `upper`, `lower`, `trim`, `stringify`, `capitalize`.
-     * Unknown keys are left untouched (the literal `{{ key }}` stays in the
-     * output) so users can spot typos easily.
+     * form templates: `upper`, `lower`, `trim`, `stringify`, `capitalize`,
+     * `slug`, `snake`, `pascal`. Unknown keys are left untouched (the literal
+     * `{{ key }}` stays in the output) so users can spot typos easily.
      */
     asString(template: string): string {
         return template.replace(

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -378,6 +378,44 @@ describe("ResultValue", () => {
             expect(resultValue.trimmed.snake.toString()).toEqual("hello_world");
         });
     });
+    describe("pascal", () => {
+        it("should convert a string to PascalCase", () => {
+            const resultValue = ResultValue.from("hello world", "Test");
+            expect(resultValue.pascal.toString()).toEqual("HelloWorld");
+        });
+        it("should treat dashes, underscores and punctuation as word boundaries", () => {
+            const resultValue = ResultValue.from("hello_world-my.note", "Test");
+            expect(resultValue.pascal.toString()).toEqual("HelloWorldMyNote");
+        });
+        it("should collapse runs of separators and trim edges", () => {
+            const resultValue = ResultValue.from("  ---My Note (2024)  ", "Test");
+            expect(resultValue.pascal.toString()).toEqual("MyNote2024");
+        });
+        it("should preserve unicode letters and numbers", () => {
+            const resultValue = ResultValue.from("café noël 2024", "Test");
+            expect(resultValue.pascal.toString()).toEqual("CaféNoël2024");
+        });
+        it("should turn camelCase into PascalCase without lowering the rest", () => {
+            const resultValue = ResultValue.from("helloWorld", "Test");
+            expect(resultValue.pascal.toString()).toEqual("HelloWorld");
+        });
+        it("should convert each string in an array individually", () => {
+            const resultValue = ResultValue.from(["foo bar", "hello world!"], "Test");
+            expect(resultValue.pascal.toString()).toEqual("FooBar, HelloWorld");
+        });
+        it("should leave non-string values unchanged in mixed arrays", () => {
+            const resultValue = ResultValue.from(["foo bar", 42], "Test");
+            expect(resultValue.pascal.bullets).toEqual("- FooBar\n- 42");
+        });
+        it("should handle an empty string without crashing", () => {
+            const resultValue = ResultValue.from("", "Test");
+            expect(resultValue.pascal.toString()).toEqual("");
+        });
+        it("should be chainable", () => {
+            const resultValue = ResultValue.from("  hello world  ", "Test");
+            expect(resultValue.trimmed.pascal.toString()).toEqual("HelloWorld");
+        });
+    });
     describe("chaining shortcuts", () => {
         it("should be possible to chain upper, lower and trim", () => {
             // Arrange

--- a/src/core/ResultValue.test.ts
+++ b/src/core/ResultValue.test.ts
@@ -395,6 +395,12 @@ describe("ResultValue", () => {
             const resultValue = ResultValue.from("café noël 2024", "Test");
             expect(resultValue.pascal.toString()).toEqual("CaféNoël2024");
         });
+        it("should upper-case supplementary-plane letters that begin a chunk", () => {
+            // Regression: `charAt(0)` returns the leading UTF-16 code unit,
+            // so a Deseret small letter (U+10428) would slip through un-cased.
+            const resultValue = ResultValue.from("\u{10428}oo bar", "Test");
+            expect(resultValue.pascal.toString()).toEqual("\u{10400}ooBar");
+        });
         it("should turn camelCase into PascalCase without lowering the rest", () => {
             const resultValue = ResultValue.from("helloWorld", "Test");
             expect(resultValue.pascal.toString()).toEqual("HelloWorld");

--- a/src/core/ResultValue.ts
+++ b/src/core/ResultValue.ts
@@ -1,7 +1,7 @@
 import { E, O, ensureError, pipe } from "@std";
 import { notifyError } from "src/utils/Log";
 import { FileProxy } from "./files/FileProxy";
-import { toSlug, toSnake } from "./template/templateParser";
+import { toPascal, toSlug, toSnake } from "./template/templateParser";
 
 function _toBulletList(value: Record<string, unknown> | unknown[]) {
     if (Array.isArray(value)) {
@@ -243,6 +243,23 @@ export class ResultValue<T = unknown> {
             return new ResultValue(toSnake(this.value.name), this.name, this.notify);
         }
         return this.map((v) => deepMap(v, (it) => (typeof it === "string" ? toSnake(it) : it)));
+    }
+
+    /**
+     * getter that returns the value converted to PascalCase. Word boundaries
+     * are any run of non-letter/number characters (whitespace, dashes,
+     * underscores, punctuation); each remaining chunk gets its first
+     * character upper-cased and the rest is preserved. Strings nested in
+     * arrays/objects are converted individually; non-string values are
+     * returned unchanged. `FileProxy` values are converted from the file
+     * name so `result.getValue('image').pascal` can drive filename
+     * generation.
+     */
+    get pascal(): ResultValue<unknown> {
+        if (this.value instanceof FileProxy) {
+            return new ResultValue(toPascal(this.value.name), this.name, this.notify);
+        }
+        return this.map((v) => deepMap(v, (it) => (typeof it === "string" ? toPascal(it) : it)));
     }
 
     /**

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -464,6 +464,21 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("CaféNoël2024"));
     });
 
+    it("pascal upper-cases supplementary-plane letters that begin a chunk", () => {
+        // Regression: `charAt(0)` returns the leading UTF-16 code unit, so
+        // a Deseret small letter (U+10428) would slip through un-cased and
+        // its surrogate pair would be split by the slice.
+        const template = "{{title|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { title: "\u{10428}oo bar" }),
+            ),
+        );
+        expect(result).toEqual(E.of("\u{10400}ooBar"));
+    });
+
     it("pascal leaves the rest of each chunk intact so camelCase becomes PascalCase", () => {
         const template = "{{title|pascal}}";
         const parsed = parseTemplate(template);

--- a/src/core/template/templateParser.test.ts
+++ b/src/core/template/templateParser.test.ts
@@ -416,6 +416,104 @@ describe("parseTemplate", () => {
         expect(result).toEqual(E.of("my_photopng"));
     });
 
+    it("Should execute a template with pascal transformation", () => {
+        const template = "{{title|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { title: "hello world" }),
+            ),
+        );
+        expect(result).toEqual(E.of("HelloWorld"));
+    });
+
+    it("pascal treats dashes, underscores and punctuation as word boundaries", () => {
+        const template = "{{title|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { title: "hello_world-my.note" }),
+            ),
+        );
+        expect(result).toEqual(E.of("HelloWorldMyNote"));
+    });
+
+    it("pascal collapses runs of separators and trims edges", () => {
+        const template = "{{title|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { title: "  ---My Note (2024)  " }),
+            ),
+        );
+        expect(result).toEqual(E.of("MyNote2024"));
+    });
+
+    it("pascal preserves unicode letters and numbers", () => {
+        const template = "{{title|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { title: "café noël 2024" }),
+            ),
+        );
+        expect(result).toEqual(E.of("CaféNoël2024"));
+    });
+
+    it("pascal leaves the rest of each chunk intact so camelCase becomes PascalCase", () => {
+        const template = "{{title|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { title: "helloWorld" }),
+            ),
+        );
+        expect(result).toEqual(E.of("HelloWorld"));
+    });
+
+    it("pascal handles an empty string without crashing", () => {
+        const template = "[{{title|pascal}}]";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { title: "" })),
+        );
+        expect(result).toEqual(E.of("[]"));
+    });
+
+    it("pascal applied to an array converts each element and joins with commas", () => {
+        const template = "{{tags|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) =>
+                executeTemplate(parsedTemplate, { tags: ["foo bar", "hello world!"] }),
+            ),
+        );
+        expect(result).toEqual(E.of("FooBar,HelloWorld"));
+    });
+
+    it("pascal applied to a FileProxy uses the file name, not the full path", () => {
+        const file = new FileProxy({
+            path: "attachments/My Photo.png",
+            name: "My Photo.png",
+            basename: "My Photo",
+            extension: "png",
+        });
+        const template = "{{image|pascal}}";
+        const parsed = parseTemplate(template);
+        const result = pipe(
+            parsed,
+            E.map((parsedTemplate) => executeTemplate(parsedTemplate, { image: file })),
+        );
+        expect(result).toEqual(E.of("MyPhotoPng"));
+    });
+
     it("should parse a frontmatter command", () => {
         const template = "{#frontmatter#}";
         const result = parseTemplate(template);

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -271,6 +271,24 @@ export function toSnake(value: string): string {
         .replace(/^_+|_+$/g, "");
 }
 
+// Converts a string into PascalCase: any run of non-letter/number characters
+// (whitespace, dashes, underscores, punctuation) is treated as a word boundary,
+// each remaining chunk's first character is upper-cased locale-aware while the
+// rest of the chunk is preserved as-is, and the chunks are concatenated. This
+// makes it a natural fit for deriving type or class names from free-form text
+// (e.g. "Café Noël 2024" → "CaféNoël2024", "hello_world" → "HelloWorld"), and
+// leaves already-camelCased identifiers like "helloWorld" → "HelloWorld"
+// intact save for the leading capital. Unicode letters and numbers are
+// preserved so the transformation stays useful for non-English users.
+export function toPascal(value: string): string {
+    return value
+        .replace(/[^\p{L}\p{N}]+/gu, " ")
+        .split(/\s+/)
+        .filter((chunk) => chunk.length > 0)
+        .map((chunk) => chunk.charAt(0).toLocaleUpperCase() + chunk.slice(1))
+        .join("");
+}
+
 // `slug` and `snake` strip punctuation, so calling `String(value)` on an array
 // would consume the comma separator and silently merge distinct values into
 // one token, and calling it on a `FileProxy` would consume path slashes and
@@ -310,6 +328,8 @@ export function executeTransformation(
                 return applyPerString(toSlug)(value);
             case "snake":
                 return applyPerString(toSnake)(value);
+            case "pascal":
+                return applyPerString(toPascal)(value);
             default:
                 return absurd(transformation);
         }

--- a/src/core/template/templateParser.ts
+++ b/src/core/template/templateParser.ts
@@ -285,7 +285,11 @@ export function toPascal(value: string): string {
         .replace(/[^\p{L}\p{N}]+/gu, " ")
         .split(/\s+/)
         .filter((chunk) => chunk.length > 0)
-        .map((chunk) => chunk.charAt(0).toLocaleUpperCase() + chunk.slice(1))
+        // `charAt(0)` returns the leading UTF-16 code unit, which splits a
+        // surrogate pair for supplementary-plane letters (e.g. Deseret
+        // U+10428 `𐐨`), leaving the letter un-cased and mangling the slice.
+        // `replace(/^./u, ...)` matches the first full code point instead.
+        .map((chunk) => chunk.replace(/^./u, (first) => first.toLocaleUpperCase()))
         .join("");
 }
 

--- a/src/core/template/templateSchema.ts
+++ b/src/core/template/templateSchema.ts
@@ -25,6 +25,7 @@ export const transformations = union([
     literal("capitalize"),
     literal("slug"),
     literal("snake"),
+    literal("pascal"),
 ]);
 
 export type Transformations = Output<typeof transformations>;


### PR DESCRIPTION
## Summary

Adds a new `pascal` transformation to the template pipeline and a matching `.pascal` getter on `ResultValue`. It joins the existing `slug` and `snake` case-conversion family and is a natural fit for deriving type names, class names, or wiki article titles from free-form field input.

## Behavior

- Any run of non-letter/number characters (whitespace, dashes, underscores, punctuation) is treated as a word boundary.
- Each remaining chunk's first character is upper-cased locale-aware while the rest of the chunk is preserved as-is, so an already-camelCased identifier like `helloWorld` becomes `HelloWorld` and edge separators are dropped.
- Unicode letters and numbers are preserved so the transformation stays useful for non-English users (`Café Noël 2024` → `CaféNoël2024`).
- Arrays are converted per-element (comma-separated in templates, same as `slug`/`snake`); `FileProxy` values are converted from the file name so a `{{ image | pascal }}` renders without eating the `/` between folder and filename.

## Examples

| Input                    | Output           |
| ------------------------ | ---------------- |
| `hello world`            | `HelloWorld`     |
| `hello_world-my.note`    | `HelloWorldMyNote` |
| `  ---My Note (2024)  `  | `MyNote2024`     |
| `helloWorld`             | `HelloWorld`     |
| `café noël 2024`         | `CaféNoël2024`   |

```plaintext
{{ title | pascal }}
```

```typescript
result.getValue('title').pascal
```

## Changes

- `src/core/template/templateSchema.ts` — add `"pascal"` to the transformations union.
- `src/core/template/templateParser.ts` — add `toPascal(value)` and wire it into `executeTransformation` via `applyPerString`, so arrays and `FileProxy` values behave like `slug`/`snake`.
- `src/core/ResultValue.ts` — add the `pascal` getter, matching the shape of `slug`/`snake` (per-element deep map, `FileProxy` → file name).
- `src/core/FormResult.ts` — update `asString` doc-comment to mention `slug`/`snake`/`pascal` alongside the older transformations.
- `docs/templates.md` and `docs/ResultValue.md` — document the new transformation with usage examples.
- Tests: eight new cases each in `templateParser.test.ts` and `ResultValue.test.ts` covering the happy path, separator collapsing, camelCase → PascalCase, Unicode preservation, empty input, arrays with mixed types, and `FileProxy` handling.

## Verification

- `npm test` — 251 passed, 2 skipped (all suites green).
- `npm run build` — full pipeline (lint + svelte-check + esbuild) passes with 0 errors; the only warnings are pre-existing (unused imports/CSS elsewhere in the codebase).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpJw35DJXAfPgf34YeSgC2)_